### PR TITLE
so/manifesto page 2.1

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -9,6 +9,10 @@
     "contact": "CONTACT",
     "buy": "BUY"
   },
+  "manifesto": {
+    "header": "Manifesto",
+    "manifesto": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+  },
   "contact": {
     "header": "Contact",
     "subheader": "Oxymore is a biannual publication bla bla bla bla",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -9,6 +9,10 @@
     "contact": "CONTACTO",
     "buy": "COMPRAR"
   },
+  "manifesto": {
+    "header": "Manifiesto",
+    "manifesto": "Lorem Ipsum es simplemente el texto de relleno de las imprentas y archivos de texto. Lorem Ipsum ha sido el texto de relleno estándar de las industrias desde el año 1500, cuando un impresor (N. del T. persona que se dedica a la imprenta) desconocido usó una galería de textos y los mezcló de tal manera que logró hacer un libro de textos especimen. No sólo sobrevivió 500 años, sino que tambien ingresó como texto de relleno en documentos electrónicos, quedando esencialmente igual al original. Fue popularizado en los 60s con la creación de las hojas Letraset, las cuales contenian pasajes de Lorem Ipsum, y más recientemente con software de autoedición, como por ejemplo Aldus PageMaker, el cual incluye versiones de Lorem Ipsum."
+  },
   "contact": {
     "header": "Contácto",
     "subheader": "Oxymore es una publicación bianual bla bla bla bla",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "styled-components";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import Home from "./components/Home";
 import Projects from "./components/Projects";
+import Manifesto from "./components/Manifesto";
 import Contact from "./components/Contact";
 import theme from "./components/theme";
 import NavMenu from "./components/NavMenu";
@@ -15,10 +16,10 @@ const App = () => {
       <ThemeProvider theme={theme}>
         <div className="App">
           <Suspense fallback={<div>Loading</div>}>
-            <NavMenu />
             <Switch>
               <Route path="/" exact component={Home} />
               <Route path="/projects" exact component={Projects} />
+              <Route path="/manifesto" exact component={Manifesto} />
               <Route path="/contact-us" exact component={Contact} />
             </Switch>
           </Suspense>

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -9,6 +9,7 @@ const GlobalStyle = createGlobalStyle`
   }
   button {
     cursor: pointer;
+    color: ${theme.colors.athensGray};
   }
   a {
     text-decoration: none;

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -10,6 +10,7 @@ const GlobalStyle = createGlobalStyle`
   button {
     cursor: pointer;
     color: ${theme.colors.athensGray};
+    outline: none;
   }
   a {
     text-decoration: none;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback } from "react";
+import styled from "styled-components";
+import {
+  space,
+  typography,
+  layout,
+  flexbox,
+  grid,
+  position,
+  SpaceProps,
+  TypographyProps,
+  LayoutProps,
+  FlexboxProps,
+  GridProps,
+  PositionProps,
+} from "styled-system";
+import NavMenu from "./NavMenu";
+import i18next from "i18next";
+import { NavLink } from "react-router-dom";
+
+const HeaderContainer = styled.div<
+  LayoutProps & SpaceProps & GridProps & PositionProps
+>`
+  background-color: black;
+  width: 100%;
+  ${layout};
+  ${space};
+  ${grid};
+  ${position};
+`;
+
+const LangButtonContainer = styled.div<FlexboxProps & GridProps & LayoutProps>`
+  background-color: black;
+  width: 100%;
+  ${flexbox};
+  ${grid};
+  ${layout};
+`;
+
+const H1 = styled.h1<SpaceProps & TypographyProps & GridProps>`
+  ${space};
+  ${typography};
+  ${grid};
+`;
+
+const LangButton = styled.button<SpaceProps & TypographyProps & GridProps>`
+  background: transparent;
+  border: none;
+  ${typography};
+  ${space};
+  ${grid};
+  transition: transform 0.2s;
+  transform-origin: left;
+  transform-origin: right;
+  &:hover {
+    transform: scale(1.05);
+`;
+
+const Header = () => {
+  const onLangClick = useCallback(
+    (countryId: string) => () => i18next.changeLanguage(countryId),
+    []
+  );
+
+  return (
+    <HeaderContainer
+      gridTemplateColumns={["repeat(4, 1fr)", "repeat(3, 1fr)"]}
+      display="grid"
+      position="absolute"
+      top={4}
+      px={7}
+    >
+      <NavLink to="/">
+        <H1
+          fontSize={[1, 2, 3, 4]}
+          py={3}
+          px={3}
+          gridColumn={1}
+          textAlign="start"
+        >
+          OXYMORE
+        </H1>
+      </NavLink>
+      <LangButtonContainer
+        gridColumn={3}
+        display="flex"
+        justifyContent="center"
+      >
+        <LangButton
+          onClick={onLangClick("en")}
+          fontSize={[1, 2, 3, 4]}
+          py={3}
+          px={[1, 2]}
+          style={{ transformOrigin: "right" }}
+        >
+          EN
+        </LangButton>
+        <LangButton
+          onClick={onLangClick("es")}
+          fontSize={[1, 2, 3, 4]}
+          py={3}
+          px={[1, 2]}
+          style={{ transformOrigin: "left" }}
+        >
+          ES
+        </LangButton>
+      </LangButtonContainer>
+      <NavMenu />
+    </HeaderContainer>
+  );
+};
+
+export default Header;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,20 +21,11 @@ import { NavLink } from "react-router-dom";
 const HeaderContainer = styled.div<
   LayoutProps & SpaceProps & GridProps & PositionProps
 >`
-  background-color: black;
   width: 100%;
   ${layout};
   ${space};
   ${grid};
   ${position};
-`;
-
-const LangButtonContainer = styled.div<FlexboxProps & GridProps & LayoutProps>`
-  background-color: black;
-  width: 100%;
-  ${flexbox};
-  ${grid};
-  ${layout};
 `;
 
 const H1 = styled.h1<SpaceProps & TypographyProps & GridProps>`
@@ -43,12 +34,23 @@ const H1 = styled.h1<SpaceProps & TypographyProps & GridProps>`
   ${grid};
 `;
 
-const LangButton = styled.button<SpaceProps & TypographyProps & GridProps>`
+const Container = styled.div<
+  FlexboxProps & GridProps & LayoutProps & SpaceProps & TypographyProps
+>`
+  background-color: black;
+  width: 100%;
+  ${flexbox};
+  ${grid};
+  ${layout};
+  ${space};
+  ${typography};
+`;
+
+const LangButton = styled.button<SpaceProps & TypographyProps>`
   background: transparent;
   border: none;
   ${typography};
   ${space};
-  ${grid};
   transition: transform 0.2s;
   transform-origin: left;
   transform-origin: right;
@@ -57,6 +59,7 @@ const LangButton = styled.button<SpaceProps & TypographyProps & GridProps>`
 `;
 
 const Header = () => {
+  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
   const onLangClick = useCallback(
     (countryId: string) => () => i18next.changeLanguage(countryId),
     []
@@ -64,48 +67,47 @@ const Header = () => {
 
   return (
     <HeaderContainer
-      gridTemplateColumns={["repeat(4, 1fr)", "repeat(3, 1fr)"]}
+      gridTemplateColumns={["repeat(3, 1fr)"]}
       display="grid"
       position="absolute"
       top={4}
-      px={7}
+      px={6}
     >
       <NavLink to="/">
-        <H1
-          fontSize={[1, 2, 3, 4]}
-          py={3}
-          px={3}
-          gridColumn={1}
-          textAlign="start"
-        >
+        <H1 py={3} px={3} gridColumn={1} fontSize={fontSizes}>
           OXYMORE
         </H1>
       </NavLink>
-      <LangButtonContainer
-        gridColumn={3}
-        display="flex"
-        justifyContent="center"
-      >
-        <LangButton
-          onClick={onLangClick("en")}
-          fontSize={[1, 2, 3, 4]}
+      <Container display="flex" flexDirection="row" gridColumn={3}>
+        <Container display="flex" py={3} px={3} fontSize={fontSizes}>
+          <LangButton
+            onClick={onLangClick("en")}
+            style={{ transformOrigin: "right" }}
+            fontSize={fontSizes}
+            mr={1}
+          >
+            EN
+          </LangButton>
+          <LangButton
+            onClick={onLangClick("es")}
+            style={{ transformOrigin: "left" }}
+            fontSize={fontSizes}
+            ml={1}
+          >
+            ES
+          </LangButton>
+        </Container>
+        <Container
+          display="flex"
+          justifyContent="flex-end"
           py={3}
-          px={[1, 2]}
-          style={{ transformOrigin: "right" }}
+          px={3}
+          gridColumn={3}
+          fontSize={fontSizes}
         >
-          EN
-        </LangButton>
-        <LangButton
-          onClick={onLangClick("es")}
-          fontSize={[1, 2, 3, 4]}
-          py={3}
-          px={[1, 2]}
-          style={{ transformOrigin: "left" }}
-        >
-          ES
-        </LangButton>
-      </LangButtonContainer>
-      <NavMenu />
+          <NavMenu />
+        </Container>
+      </Container>
     </HeaderContainer>
   );
 };

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -69,7 +69,6 @@ const Home = () => {
       >
         <img src={oxymore} />
       </Logo>
-      <NavMenu />
       <Logo width={[100, 200, 300, 400, 500]}>
         <Link to="/projects" style={{ textDecoration: "none" }}>
           <img src={alpha} />

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -45,10 +45,13 @@ const Paragraph = styled.p<TypographyProps & SpaceProps>`
   text-transform: uppercase;
   ${typography};
   ${space};
+  padding-bottom: 20px;
+  text-align: justify;
 `;
 
 const Manifesto = () => {
   const { t } = useTranslation();
+  const fontSizes = [1, null, null, null, 2, 3, 4];
 
   return (
     <Main p={7} alignItems="center" justifyContent="center">
@@ -73,26 +76,12 @@ const Manifesto = () => {
             null,
             null,
             "repeat(2, 47.5% [col-start])",
-
             "repeat(2, 48.5% [col-start])",
-
             "repeat(2, 49% [col-start])",
           ]}
         >
-          <Paragraph
-            fontSize={[1, null, null, null, 2, 3, 4]}
-            textAlign="justify"
-            pb={5}
-          >
-            {t("manifesto.manifesto")}
-          </Paragraph>
-          <Paragraph
-            fontSize={[1, null, null, null, 2, 3, 4]}
-            textAlign="justify"
-            pb={5}
-          >
-            {t("manifesto.manifesto")}
-          </Paragraph>
+          <Paragraph fontSize={fontSizes}>{t("manifesto.manifesto")}</Paragraph>
+          <Paragraph fontSize={fontSizes}>{t("manifesto.manifesto")}</Paragraph>
         </Grid>
       </Container>
     </Main>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -51,15 +51,15 @@ const Paragraph = styled.p<TypographyProps & SpaceProps>`
 
 const Manifesto = () => {
   const { t } = useTranslation();
-  const fontSizes = [1, null, null, null, 2, 3, 4];
+  const fontSizes = [1, 2, null, null, 2, 3, 4];
 
   return (
-    <Main p={7} alignItems="center" justifyContent="center">
+    <Main p={6} alignItems="center" justifyContent="center">
       <Header />
       <Container
         display="block"
         px={4}
-        mt={["20%", null, null, null, null, null, null, "10%", "0%"]}
+        mt={["20%", null, null, null, null, null, null, "10%", "0"]}
       >
         <H1 fontSize={[2, null, null, null, 3, 4, 5]} pb={5}>
           {t("manifesto.header")}

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -56,7 +56,7 @@ const Manifesto = () => {
       <Container
         display="block"
         px={4}
-        mt={["20%", null, null, null, null, null, "10%"]}
+        mt={["20%", null, null, null, null, null, null, "10%", "0%"]}
       >
         <H1 fontSize={[2, null, null, null, 3, 4, 5]} pb={5}>
           {t("manifesto.header")}
@@ -71,9 +71,11 @@ const Manifesto = () => {
             null,
             null,
             null,
-            "repeat(2, 47% [col-start])",
+            null,
             "repeat(2, 47.5% [col-start])",
+
             "repeat(2, 48.5% [col-start])",
+
             "repeat(2, 49% [col-start])",
           ]}
         >

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -2,109 +2,94 @@ import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
-  color,
   layout,
   space,
   typography,
-  background,
   flexbox,
-  border,
   grid,
-  ColorProps,
   LayoutProps,
   SpaceProps,
   TypographyProps,
-  BackgroundProps,
   FlexboxProps,
-  BorderProps,
   GridProps,
 } from "styled-system";
+import Header from "./Header";
 
-const Main = styled.main<
-  ColorProps & SpaceProps & BackgroundProps & LayoutProps & FlexboxProps
->`
+const Main = styled.main<SpaceProps & LayoutProps & FlexboxProps>`
   min-height: 100vh;
-  overflow: hidden;
-  ${color};
+  background: black;
+  display: flex;
   ${space};
-  ${background};
   ${layout};
   ${flexbox}
 `;
 
-const H1 = styled.h1<ColorProps & TypographyProps & SpaceProps>`
-  text-transform: uppercase;
-  ${color};
-  ${typography};
+const Container = styled.div<
+  SpaceProps & LayoutProps & GridProps & FlexboxProps
+>`
   ${space};
+  ${layout};
+  ${grid};
+  ${flexbox};
 `;
 
-const Grid = styled.div<GridProps & FlexboxProps & SpaceProps>`
+const Grid = styled.div<GridProps & FlexboxProps>`
   display: grid;
   ${grid};
   ${flexbox};
-  ${space};
 `;
 
-const Container = styled.div<
-  ColorProps & SpaceProps & BorderProps & LayoutProps
->`
-  ${color};
-  ${space};
-  ${border}
-  ${layout};
-`;
-
-const Paragraph = styled.p<ColorProps & TypographyProps & SpaceProps>`
+const H1 = styled.h1<TypographyProps & SpaceProps & GridProps>`
   text-transform: uppercase;
-  ${color};
   ${typography};
   ${space};
+  ${grid};
+`;
+
+const Paragraph = styled.p<
+  TypographyProps & SpaceProps & FlexboxProps & GridProps
+>`
+  text-transform: uppercase;
+  ${typography};
+  ${space};
+  ${flexbox};
+  ${grid};
 `;
 
 const Manifesto = () => {
   const { t } = useTranslation();
 
   return (
-    <Main
-      bg="black"
-      px={[1, 4, 6]}
-      pt={5}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-    >
-      <Container p={4} display="block">
-        <H1 color="athensGray" fontSize={[2, 4, 5]} pb={5}>
+    <Main p={7} alignItems="center" justifyContent="center">
+      <Header />
+      <Container
+        display="block"
+        px={4}
+        mt={["20%", null, null, null, null, null, "0%"]}
+      >
+        <H1 fontSize={[2, 4, 5]} pb={5}>
           {t("manifesto.header")}
         </H1>
         <Grid
           justifyContent="center"
-          gridColumnGap={5}
-          gridRowGap={1}
+          gridColumnGap={10}
           gridTemplateColumns={[
             "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(2, 49% [col-start])",
+            null,
+            null,
+            null,
+            null,
+            null,
+            "repeat(2, 47% [col-start])",
+            "repeat(2, 47.5% [col-start])",
+            "repeat(2, 48.5% [col-start])",
             "repeat(2, 49% [col-start])",
           ]}
         >
-          <Paragraph
-            color="athensGray"
-            fontSize={[1, 3, 4]}
-            textAlign="justify"
-            pb={5}
-          >
+          <Paragraph fontSize={[1, 3, 4]} textAlign="justify" pb={5}>
             {t("manifesto.manifesto")}
           </Paragraph>
-          <Paragraph
-            color="athensGray"
-            fontSize={[1, 3, 4]}
-            textAlign="justify"
-            pb={5}
-          >
+          <Paragraph fontSize={[1, 3, 4]} textAlign="justify" pb={5}>
             {t("manifesto.manifesto")}
           </Paragraph>
         </Grid>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -15,22 +15,17 @@ import {
 } from "styled-system";
 import Header from "./Header";
 
-const Main = styled.main<SpaceProps & LayoutProps & FlexboxProps>`
+const Main = styled.main<SpaceProps & FlexboxProps>`
   min-height: 100vh;
   background: black;
   display: flex;
   ${space};
-  ${layout};
   ${flexbox}
 `;
 
-const Container = styled.div<
-  SpaceProps & LayoutProps & GridProps & FlexboxProps
->`
+const Container = styled.div<SpaceProps & LayoutProps>`
   ${space};
   ${layout};
-  ${grid};
-  ${flexbox};
 `;
 
 const Grid = styled.div<GridProps & FlexboxProps>`
@@ -46,14 +41,10 @@ const H1 = styled.h1<TypographyProps & SpaceProps & GridProps>`
   ${grid};
 `;
 
-const Paragraph = styled.p<
-  TypographyProps & SpaceProps & FlexboxProps & GridProps
->`
+const Paragraph = styled.p<TypographyProps & SpaceProps>`
   text-transform: uppercase;
   ${typography};
   ${space};
-  ${flexbox};
-  ${grid};
 `;
 
 const Manifesto = () => {
@@ -65,9 +56,9 @@ const Manifesto = () => {
       <Container
         display="block"
         px={4}
-        mt={["20%", null, null, null, null, null, "0%"]}
+        mt={["20%", null, null, null, null, null, "10%"]}
       >
-        <H1 fontSize={[2, 4, 5]} pb={5}>
+        <H1 fontSize={[2, null, null, null, 3, 4, 5]} pb={5}>
           {t("manifesto.header")}
         </H1>
         <Grid
@@ -86,10 +77,18 @@ const Manifesto = () => {
             "repeat(2, 49% [col-start])",
           ]}
         >
-          <Paragraph fontSize={[1, 3, 4]} textAlign="justify" pb={5}>
+          <Paragraph
+            fontSize={[1, null, null, null, 2, 3, 4]}
+            textAlign="justify"
+            pb={5}
+          >
             {t("manifesto.manifesto")}
           </Paragraph>
-          <Paragraph fontSize={[1, 3, 4]} textAlign="justify" pb={5}>
+          <Paragraph
+            fontSize={[1, null, null, null, 2, 3, 4]}
+            textAlign="justify"
+            pb={5}
+          >
             {t("manifesto.manifesto")}
           </Paragraph>
         </Grid>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -55,7 +55,6 @@ const Manifesto = () => {
 
   return (
     <Main p={6} alignItems="center" justifyContent="center">
-      <Header />
       <Container
         display="block"
         px={4}

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -4,17 +4,17 @@ import styled, { css } from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
   color,
-  layout,
   space,
   typography,
   position,
   grid,
+  flexbox,
   ColorProps,
-  LayoutProps,
   SpaceProps,
   TypographyProps,
   PositionProps,
   GridProps,
+  FlexboxProps,
 } from "styled-system";
 
 const overlayStyles = css`
@@ -34,28 +34,21 @@ const Overlay = styled.dialog<{ isOpen: boolean }>`
   ${(props) => props.isOpen && overlayStyles}
 `;
 
-const Logo = styled.p<PositionProps & LayoutProps & TypographyProps>`
-${position}
-${layout}
-${typography}
+const Logo = styled.p<PositionProps & TypographyProps>`
+  ${position}
+  ${typography}
 `;
 
 const MenuButton = styled.button<
-  LayoutProps & TypographyProps & SpaceProps & GridProps & PositionProps
+  TypographyProps & PositionProps & FlexboxProps & SpaceProps
 >`
   display: grid;
   border: none;
   background: transparent;
-  ${layout}
   ${typography}
-  ${space}
-  ${grid}
   ${position}
-`;
-
-const Grid = styled.div<GridProps>`
-  display: grid;
-  ${grid};
+  ${flexbox}
+  ${space}
 `;
 
 const MenuContainer = styled.div<SpaceProps>`
@@ -67,15 +60,14 @@ const Menu = styled.ul<GridProps & TypographyProps>`
   ${typography};
 `;
 
-const MenuLink = styled(NavLink)<ColorProps & SpaceProps & TypographyProps>`
+const MenuLink = styled(NavLink)<ColorProps & TypographyProps>`
   ${color};
-  ${space};
   ${typography};
   }
 `;
 
 const MenuText = styled.li`
-  transition: transform 2s;
+  transition: transform 0.4s;
   &:hover {
     transform: scale(1.01);
     transform-origin: left;
@@ -94,7 +86,7 @@ const Link = ({ page, url }: LinkProps) => {
         <MenuLink
           to={url}
           color="black"
-          fontSize={[3, 4, 5, 6, null, 7, null, 8]}
+          fontSize={[3, 4, 5, 6, null, 7, 9, 10]}
         >
           {page}
         </MenuLink>
@@ -106,6 +98,7 @@ const Link = ({ page, url }: LinkProps) => {
 const NavMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useTranslation();
+  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
   const Links: LinkProps[] = [
     {
       page: `${t("nav.about-us")}`,
@@ -133,46 +126,34 @@ const NavMenu = () => {
     <Fragment>
       <MenuButton
         onClick={() => setIsOpen(!isOpen)}
-        fontSize={[1, 2, 3, 4]}
-        gridColumn={4}
-        py={3}
-        px={3}
+        fontSize={fontSizes}
+        justifySelf="end"
       >
         MENU
       </MenuButton>
       <Overlay isOpen={isOpen}>
-        <Logo fontSize={3} position="absolute" left={30} top={30}>
+        <Logo fontSize={fontSizes} position="absolute" left={30} top={24}>
           OXYMORE
         </Logo>
+
         <MenuButton
           onClick={() => setIsOpen(false)}
-          style={{ outline: "none" }}
-          fontSize={3}
+          style={{ outline: "none", color: "black" }}
+          fontSize={fontSizes}
           position="absolute"
           right={30}
-          top={30}
+          top={24}
         >
           BACK
         </MenuButton>
 
-        <Grid
-          gridColumnGap={5}
-          gridRowGap={4}
-          gridTemplateColumns={[
-            "20px 1fr 20px",
-            "10px 1fr 10px",
-            "10px 1fr 10px",
-            "1fr 10px 10px",
-          ]}
+        <Menu
+          onClick={() => setIsOpen(!isOpen)}
+          textAlign={["center", null, null, "start"]}
+          gridColumn={["2/3", null, null, "1/2"]}
         >
-          <Menu
-            onClick={() => setIsOpen(!isOpen)}
-            textAlign={["center", null, null, "start"]}
-            gridColumn={["2/3", null, null, "1/2"]}
-          >
-            {Links.map(Link)}
-          </Menu>
-        </Grid>
+          {Links.map(Link)}
+        </Menu>
       </Overlay>
     </Fragment>
   );

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -2,138 +2,178 @@ import React, { useState, Fragment } from "react";
 import { NavLink } from "react-router-dom";
 import styled, { css } from "styled-components";
 import { useTranslation } from "react-i18next";
-import menuButton from "./assets/nav-menu/menu-button.png";
 import {
+  color,
+  layout,
   space,
+  typography,
+  position,
+  grid,
+  ColorProps,
+  LayoutProps,
   SpaceProps,
   TypographyProps,
-  typography,
-  layout,
-  LayoutProps,
-  position,
   PositionProps,
-  color,
-  ColorProps,
-  border,
-  BorderProps,
+  GridProps,
 } from "styled-system";
 
-const visibleStyles = css`
+const overlayStyles = css`
   display: flex;
   flex-direction: column;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.1);
-  font-size: 36px;
-  justify-content: center;
-  text-align: center;
+  height: 100vh;
   width: 100%;
-  font-family: SangBleu OG Serif Light Regular;
+  justify-content: center;
   border: none;
+  background-image: url("/assets/nav-menu/background-inverted.png");
+  background-size: cover;
+  opacity: 1;
 `;
-const NavMenuOverlay = styled.dialog<{ isOpen: boolean }>`
+
+const Overlay = styled.dialog<{ isOpen: boolean }>`
   display: none;
-  ${(props) => props.isOpen && visibleStyles}
+  ${(props) => props.isOpen && overlayStyles}
 `;
 
-type MenuProps = SpaceProps &
-  TypographyProps &
-  PositionProps &
-  LayoutProps &
-  ColorProps &
-  BorderProps;
+const Logo = styled.p<PositionProps & LayoutProps & TypographyProps>`
+${position}
+${layout}
+${typography}
+`;
 
-const MenuButton = styled.button<MenuProps>`
-  ${position}
+const MenuButton = styled.button<
+  LayoutProps & TypographyProps & SpaceProps & GridProps & PositionProps
+>`
+  display: grid;
+  border: none;
+  background: transparent;
   ${layout}
-  ${border}
-  ${color}
-`;
-
-const MenuItem = styled.li<MenuProps>`
-  ${space}
   ${typography}
-  ${layout}
-  ${color}
-  &:focus,
-  &:hover {
-    font-size: 32px;
-  }
-  &:visited,
-  &:link,
-  &:active {
-    text-decoration: none;
+  ${space}
+  ${grid}
+  ${position}
+`;
+
+const Grid = styled.div<GridProps>`
+  display: grid;
+  ${grid};
+`;
+
+const MenuContainer = styled.div<SpaceProps>`
+  ${space};
+`;
+
+const Menu = styled.ul<GridProps & TypographyProps>`
+  ${grid};
+  ${typography};
+`;
+
+const MenuLink = styled(NavLink)<ColorProps & SpaceProps & TypographyProps>`
+  ${color};
+  ${space};
+  ${typography};
   }
 `;
+
+const MenuText = styled.li`
+  transition: transform 2s;
+  &:hover {
+    transform: scale(1.01);
+    transform-origin: left;
+  }
+`;
+
+interface LinkProps {
+  page: string;
+  url: string;
+}
+
+const Link = ({ page, url }: LinkProps) => {
+  return (
+    <MenuContainer key={page} p={1}>
+      <MenuText>
+        <MenuLink
+          to={url}
+          color="black"
+          fontSize={[3, 4, 5, 6, null, 7, null, 8]}
+        >
+          {page}
+        </MenuLink>
+      </MenuText>
+    </MenuContainer>
+  );
+};
 
 const NavMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useTranslation();
+  const Links: LinkProps[] = [
+    {
+      page: `${t("nav.about-us")}`,
+      url: "/about-us",
+    },
+    {
+      page: `${t("nav.manifesto")}`,
+      url: "/manifesto",
+    },
+    {
+      page: `${t("nav.contact")}`,
+      url: "/contact-us",
+    },
+    {
+      page: `${t("nav.advertising")}`,
+      url: "/advertising",
+    },
+    {
+      page: `${t("nav.buy")}`,
+      url: "/buy",
+    },
+  ];
 
   return (
     <Fragment>
       <MenuButton
         onClick={() => setIsOpen(!isOpen)}
-        position="absolute"
-        right={30}
-        top={30}
-        width={50}
-        border="none"
-        bg="transparent"
-        style={{ outline: "none" }}
-        color="athensGray"
+        fontSize={[1, 2, 3, 4]}
+        gridColumn={4}
+        py={3}
+        px={3}
       >
         MENU
       </MenuButton>
-      <NavMenuOverlay isOpen={isOpen} onClick={() => setIsOpen(false)}>
-        <ul>
-          <MenuItem
-            fontSize={[4, 4, 5, 5, 5]}
-            p={[1, 2, 4, 4]}
-            color="black"
-            height={[44, 44, 66, 66, 66]}
-          >
-            {t("nav.manifesto")} <NavLink to="/manifesto"></NavLink>
-          </MenuItem>
+      <Overlay isOpen={isOpen}>
+        <Logo fontSize={3} position="absolute" left={30} top={30}>
+          OXYMORE
+        </Logo>
+        <MenuButton
+          onClick={() => setIsOpen(false)}
+          style={{ outline: "none" }}
+          fontSize={3}
+          position="absolute"
+          right={30}
+          top={30}
+        >
+          BACK
+        </MenuButton>
 
-          <MenuItem
-            fontSize={[4, 4, 5, 5, 5]}
-            p={[1, 2, 4, 4]}
-            color="black"
-            height={[44, 44, 66, 66, 66]}
+        <Grid
+          gridColumnGap={5}
+          gridRowGap={4}
+          gridTemplateColumns={[
+            "20px 1fr 20px",
+            "10px 1fr 10px",
+            "10px 1fr 10px",
+            "1fr 10px 10px",
+          ]}
+        >
+          <Menu
+            onClick={() => setIsOpen(!isOpen)}
+            textAlign={["center", null, null, "start"]}
+            gridColumn={["2/3", null, null, "1/2"]}
           >
-            {t("nav.advertising")}
-            <NavLink to="/advertising"></NavLink>
-          </MenuItem>
-
-          <MenuItem
-            fontSize={[4, 4, 5, 5, 5]}
-            p={[1, 2, 4, 4]}
-            color="black"
-            height={[44, 44, 66, 66, 66]}
-          >
-            {t("nav.about-us")}
-            <NavLink to="/about-us"></NavLink>
-          </MenuItem>
-
-          <MenuItem
-            fontSize={[4, 4, 5, 5, 5]}
-            p={[1, 2, 4, 4]}
-            color="black"
-            height={[44, 44, 66, 66, 66]}
-          >
-            {t("nav.contact")} <NavLink to="/contact"></NavLink>
-          </MenuItem>
-
-          <MenuItem
-            fontSize={[4, 4, 5, 5, 5]}
-            p={[1, 2, 4, 4]}
-            color="black"
-            height={[44, 44, 66, 66, 66]}
-          >
-            {t("nav.buy")} <NavLink to="/buy"></NavLink>
-          </MenuItem>
-        </ul>
-      </NavMenuOverlay>
+            {Links.map(Link)}
+          </Menu>
+        </Grid>
+      </Overlay>
     </Fragment>
   );
 };

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -74,6 +74,8 @@ const fontSizes = {
   6: 40,
   7: 50,
   8: 60,
+  9: 70,
+  10: 80,
 };
 
 const space = {


### PR DESCRIPTION
### What changes have you made?

- added `Header` component 
- added `Global Styles` component 
- minor correction on responsive paragraph and header alignment 

### Which issue(s) does this PR fix?

Fixes #4 

### Screenshots (if there are design changes)

<img width="1439" alt="Screenshot 2020-07-22 at 14 04 30" src="https://user-images.githubusercontent.com/53219789/88174305-5ed30c80-cc24-11ea-9aed-1f0a9cf1362d.png">
<img width="317" alt="Screenshot 2020-07-22 at 14 05 50" src="https://user-images.githubusercontent.com/53219789/88174379-7ca07180-cc24-11ea-8265-d5eeb72b459a.png">


### How to test
`yarn start` and nav to `localhost:3000/manifesto` 

