### PR TITLE
so/fix image sizes on homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ const App = () => {
         <div className="App">
           <Suspense fallback={<div>Loading</div>}>
             <Switch>
-              <Route path="/" exact component={Home} />
+              <Route path="/oxymore" exact component={Home} />
               <Route path="/projects" exact component={Projects} />
               <Route path="/contact-us" exact component={Contact} />
             </Switch>

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -3,7 +3,7 @@ import theme from "./components/theme";
 
 const GlobalStyle = createGlobalStyle`
   body {
-    font-family: "helvetica neue";
+    font-family: "Helvetica Neue";
     text-decoration: none;
     color: ${theme.colors.athensGray};
     background: ${theme.colors.black};

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -55,13 +55,12 @@ const Img = styled.img<LayoutProps & FlexboxProps>`
 
 const Home = () => {
   return (
-    <Main gridTemplateRows="repeat(3, 1fr)" gridTemplateColumns="25% 50% 25%">
-      <Container
-        gridRow={1}
-        gridColumn={1}
-        p={6}
-        gridTemplateRows="max-content"
-      >
+    <Main
+      gridTemplateRows="repeat(3, 1fr)"
+      gridTemplateColumns="25% 50% 25%"
+      p={6}
+    >
+      <Container gridRow={1} gridColumn={1} gridTemplateRows="max-content">
         <PageLink to="/">
           <Img src={oxymore}></Img>
         </PageLink>
@@ -86,17 +85,11 @@ const Home = () => {
           <Img src={alpha}></Img>
         </PageLink>
       </Container>
-      <Container
-        gridRow={3}
-        gridColumn={1}
-        alignSelf="end"
-        width="min-content"
-        p={6}
-      >
+      <Container gridRow={3} gridColumn={1} alignSelf="end" width="min-content">
         <Img src={number} alignSelf="center" width="40%"></Img>
         <BuyButton />
       </Container>
-      <Container gridRow={3} gridColumn={3} alignSelf="end" p={6}>
+      <Container gridRow={3} gridColumn={3} alignSelf="end">
         <PageLink to="/manifesto">
           <Img src={manifesto}></Img>
         </PageLink>

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -133,7 +133,6 @@ const NavMenu = () => {
         onClick={() => setIsOpen(!isOpen)}
         fontSize={fontSizes}
         justifySelf="end"
-        p={6}
       >
         MENU
       </MenuButton>


### PR DESCRIPTION
### What changes have you made?

- removed container padding and added global padding on the `<Main>` tag so that images don't display too small on mobile
- applied `max-content` on each of the clickable elements as per @mantagen 's PR comments on #78 
- pathname has now been updated to `/oxymore` 

### Which issue(s) does this PR fix?

Fixes #85 

### Screenshots (if there are design changes)
<img width="311" alt="Screenshot 2020-07-29 at 13 18 36" src="https://user-images.githubusercontent.com/53219789/88793989-078de880-d19e-11ea-923f-36507390a896.png">



### How to test
`yarn start` and nav to `localhost:3000/oxymore` 