### PR TITLE
so/fix nav menu display issue

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,7 +29,8 @@ const HeaderContainer = styled.div<
   ${flexbox};
 `;
 
-const H1 = styled.h1<SpaceProps & TypographyProps & GridProps>`
+const H1 = styled.h1<SpaceProps & TypographyProps>`
+  ${space};
   ${typography};
 `;
 
@@ -49,13 +50,15 @@ const Header = () => {
       gridTemplateColumns={["repeat(3, 1fr)"]}
       display="grid"
       position="absolute"
-      top={6}
+      top={0}
       alignItems="center"
       px={8}
     >
-      <NavLink to="/">
+      <NavLink to="/oxymore">
         <Container gridColumn={1}>
-          <H1 fontSize={fontSizes}>OXYMORE</H1>
+          <H1 fontSize={fontSizes} pt={6}>
+            OXYMORE
+          </H1>
         </Container>
       </NavLink>
       <Container display="flex" gridColumn={3} justifyContent="space-between">

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -10,6 +10,8 @@ import {
   SpaceProps,
   FlexboxProps,
   GridProps,
+  position,
+  PositionProps,
 } from "styled-system";
 import BuyButton from "./BuyButton";
 import NavMenu from "./NavMenu";
@@ -17,6 +19,7 @@ import oxymore from "./assets/home-page/oxymore.png";
 import manifesto from "./assets/home-page/manifesto.png";
 import number from "./assets/home-page/number-one.png";
 import alpha from "./assets/home-page/360_alpha.png";
+import Header from "./Header";
 
 const Main = styled.main<SpaceProps & FlexboxProps & GridProps>`
   background: black;
@@ -29,40 +32,32 @@ const Main = styled.main<SpaceProps & FlexboxProps & GridProps>`
 `;
 
 const Container = styled.div<
-  LayoutProps & FlexboxProps & GridProps & SpaceProps
+  LayoutProps & FlexboxProps & GridProps & SpaceProps & PositionProps
 >`
   display: grid;
   ${layout};
   ${flexbox};
   ${grid};
   ${space};
+  ${position}
 `;
 
-const PageLink = styled(NavLink)<
-  LayoutProps & FlexboxProps & GridProps & SpaceProps
->`
+const PageLink = styled(NavLink)`
   display: grid;
-  ${layout};
-  ${flexbox};
-  ${grid};
-  ${space};
 `;
 
-const Img = styled.img<LayoutProps & FlexboxProps>`
+const Img = styled.img<LayoutProps & FlexboxProps & PositionProps>`
   ${layout};
   ${flexbox};
+  ${position}
 `;
 
 const Home = () => {
   return (
-    <Main
-      gridTemplateRows="repeat(3, 1fr)"
-      gridTemplateColumns="25% 50% 25%"
-      p={6}
-    >
+    <Main gridTemplateRows="repeat(3, 1fr)" gridTemplateColumns="25% 50% 25%">
       <Container gridRow={1} gridColumn={1} gridTemplateRows="max-content">
         <PageLink to="/">
-          <Img src={oxymore}></Img>
+          <Img src={oxymore} position="relative" top={6} left={6}></Img>
         </PageLink>
       </Container>
       <Container
@@ -71,6 +66,7 @@ const Home = () => {
         gridTemplateRows="max-content"
         gridTemplateColumns="max-content"
         justifyContent="flex-end"
+        pr={6}
       >
         <NavMenu />
       </Container>
@@ -85,13 +81,21 @@ const Home = () => {
           <Img src={alpha}></Img>
         </PageLink>
       </Container>
-      <Container gridRow={3} gridColumn={1} alignSelf="end" width="min-content">
+      <Container
+        gridRow={3}
+        gridColumn={1}
+        alignSelf="end"
+        width="min-content"
+        position="relative"
+        bottom={6}
+        left={6}
+      >
         <Img src={number} alignSelf="center" width="40%"></Img>
         <BuyButton />
       </Container>
       <Container gridRow={3} gridColumn={3} alignSelf="end">
         <PageLink to="/manifesto">
-          <Img src={manifesto}></Img>
+          <Img src={manifesto} position="relative" bottom={6} right={6}></Img>
         </PageLink>
       </Container>
     </Main>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -2,111 +2,85 @@ import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
-  color,
   layout,
   space,
   typography,
-  background,
   flexbox,
-  border,
   grid,
-  ColorProps,
   LayoutProps,
   SpaceProps,
   TypographyProps,
-  BackgroundProps,
   FlexboxProps,
-  BorderProps,
   GridProps,
 } from "styled-system";
+import Header from "./Header";
 
-const Main = styled.main<
-  ColorProps & SpaceProps & BackgroundProps & LayoutProps & FlexboxProps
->`
-  min-height: 100vh;
-  overflow: hidden;
-  ${color};
+const Main = styled.main<SpaceProps & FlexboxProps>`
+  height: 100vh;
+  display: flex;
+
   ${space};
-  ${background};
-  ${layout};
   ${flexbox}
 `;
 
-const H1 = styled.h1<ColorProps & TypographyProps & SpaceProps>`
-  text-transform: uppercase;
-  ${color};
-  ${typography};
+const Container = styled.div<SpaceProps & LayoutProps>`
   ${space};
-`;
-
-const Grid = styled.div<GridProps & FlexboxProps & SpaceProps>`
-  display: grid;
-  ${grid};
-  ${flexbox};
-  ${space};
-`;
-
-const Container = styled.div<
-  ColorProps & SpaceProps & BorderProps & LayoutProps
->`
-  ${color};
-  ${space};
-  ${border}
   ${layout};
 `;
 
-const Paragraph = styled.p<ColorProps & TypographyProps & SpaceProps>`
+const Grid = styled.div<GridProps & FlexboxProps>`
+  display: grid;
+  ${grid};
+  ${flexbox};
+`;
+
+const H1 = styled.h1<TypographyProps & SpaceProps & GridProps>`
   text-transform: uppercase;
-  ${color};
   ${typography};
   ${space};
+  ${grid};
+`;
+
+const Paragraph = styled.p<TypographyProps & SpaceProps>`
+  text-transform: uppercase;
+  ${typography};
+  ${space};
+  padding-bottom: 20px;
+  text-align: justify;
 `;
 
 const Manifesto = () => {
   const { t } = useTranslation();
+  const fontSizes = [1, 2, null, null, 2, 3, 4];
 
   return (
-    <Main
-      bg="black"
-      px={[1, 4, 6]}
-      pt={5}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-    >
-      <Container p={4} display="block">
-        <H1 color="athensGray" fontSize={[2, 4, 5]} pb={5}>
+    <Main p={8} alignItems="center" justifyContent="center">
+      <Header />
+      <Container
+        display="block"
+        mt={["60%", null, null, "80%", "80%", "40%", null, "10%", "0"]}
+      >
+        <H1 fontSize={[2, null, null, null, 3, 4, 5]} pb={5}>
           {t("manifesto.header")}
         </H1>
         <Grid
           justifyContent="center"
-          gridColumnGap={5}
-          gridRowGap={1}
+          gridColumnGap={10}
           gridTemplateColumns={[
             "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(2, 49% [col-start])",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "repeat(2, 47.5% [col-start])",
+            "repeat(2, 48.5% [col-start])",
             "repeat(2, 49% [col-start])",
           ]}
         >
-          <Paragraph
-            color="athensGray"
-            fontSize={[1, 3, 4]}
-            textAlign="justify"
-            pb={5}
-          >
-            {t("manifesto.manifesto")}
-          </Paragraph>
-          <Paragraph
-            color="athensGray"
-            fontSize={[1, 3, 4]}
-            textAlign="justify"
-            pb={5}
-          >
-            {t("manifesto.manifesto")}
-          </Paragraph>
+          <Paragraph fontSize={fontSizes}>{t("manifesto.manifesto")}</Paragraph>
+          <Paragraph fontSize={fontSizes}>{t("manifesto.manifesto")}</Paragraph>
         </Grid>
       </Container>
     </Main>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -58,7 +58,7 @@ const Manifesto = () => {
       <Header />
       <Container
         display="block"
-        mt={["60%", null, null, "80%", "80%", "40%", null, "10%", "0"]}
+        mt={["60%", null, null, "80%", "80%", "80%", "40%", "10%"]}
       >
         <H1 fontSize={[2, null, null, null, 3, 4, 5]} pb={5}>
           {t("manifesto.header")}

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -34,13 +34,14 @@ const Overlay = styled.dialog<{ isOpen: boolean }>`
   ${(props) => props.isOpen && overlayStyles}
 `;
 
-const Logo = styled.p<PositionProps & TypographyProps>`
+const Logo = styled(NavLink)<PositionProps & TypographyProps & ColorProps>`
   ${position};
   ${typography};
+  ${color};
 `;
 
 const MenuButton = styled.button<
-  TypographyProps & PositionProps & FlexboxProps & SpaceProps
+  TypographyProps & PositionProps & FlexboxProps & SpaceProps & ColorProps
 >`
   display: grid;
   border: none;
@@ -49,6 +50,7 @@ const MenuButton = styled.button<
   ${position};
   ${flexbox};
   ${space};
+  ${color}
 `;
 
 const MenuContainer = styled.div<SpaceProps & GridProps>`
@@ -86,13 +88,10 @@ const Link = ({ page, url }: LinkProps) => {
       key={page}
       gridTemplateRows="max-content"
       gridTemplateColumns="max-content"
+      px={4}
     >
       <MenuText>
-        <MenuLink
-          to={url}
-          color="black"
-          fontSize={[3, 4, 5, 6, null, 7, 9, 10]}
-        >
+        <MenuLink to={url} color="black" fontSize={[3, 4, 5, 6, null, 7, 8]}>
           {page}
         </MenuLink>
       </MenuText>
@@ -133,17 +132,25 @@ const NavMenu = () => {
         onClick={() => setIsOpen(!isOpen)}
         fontSize={fontSizes}
         justifySelf="end"
+        pt={6}
       >
         MENU
       </MenuButton>
       <Overlay isOpen={isOpen}>
-        <Logo fontSize={fontSizes} position="absolute" left={30} top={24}>
+        <Logo
+          to="/oxymore"
+          fontSize={fontSizes}
+          position="absolute"
+          left={30}
+          top={24}
+          color="black"
+        >
           OXYMORE
         </Logo>
 
         <MenuButton
           onClick={() => setIsOpen(false)}
-          style={{ outline: "none", color: "black" }}
+          color="black"
           fontSize={fontSizes}
           position="absolute"
           right={30}


### PR DESCRIPTION
### What changes have you made?

- fixed display issue on the nav menu using the `Homepage` and `Manifesto` page as test cases
- included the Manifesto and Homepage so you can see the fix interacting with the two components

**Nb** a second issue has come up on the `NavMenu` overlay such that it won't cover the full height of the page unless the `overflow` is hidden - see image below. will open a new ticket for this 

<img width="328" alt="Screenshot 2020-08-04 at 17 22 16" src="https://user-images.githubusercontent.com/53219789/89312348-7627e600-d677-11ea-8c98-4a091c181c2b.png">


### Which issue(s) does this PR fix?

Fixes #92 

### Screenshots (if there are design changes)
Before ➡️

<img width="1440" alt="Screenshot 2020-08-04 at 13 44 01" src="https://user-images.githubusercontent.com/53219789/89313362-b176e480-d678-11ea-86c6-10985d7bb17d.png">


After ➡️

<img width="1440" alt="Screenshot 2020-08-04 at 17 27 14" src="https://user-images.githubusercontent.com/53219789/89312620-c30bbc80-d677-11ea-9242-263c2784dbc5.png">


### How to test
test using the Menu button on the Homepage or the Manifesto page 