### PR TITLE
reduces breakpoint usage and refactors homepage using flex

### DIFF
--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -9,13 +9,15 @@ import {
   typography,
   border,
   background,
+  LayoutProps,
+  layout,
 } from "styled-system";
 import styled from "styled-components";
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
 
 const Button = styled.button<
-  SpaceProps & TypographyProps & BorderProps & BackgroundProps
+  SpaceProps & TypographyProps & BorderProps & BackgroundProps & LayoutProps
 >`
   width: auto;
   white-space: nowrap;
@@ -23,6 +25,7 @@ const Button = styled.button<
   ${typography};
   ${border};
   ${background};
+  ${layout};
 `;
 
 const stripePromise = loadStripe(`${process.env.REACT_APP_STRIPE_API_KEY}`);
@@ -66,13 +69,14 @@ const BuyButton = () => {
       <Button
         role="link"
         onClick={handleClick}
-        fontSize={[0, null, null, null, null, 1, 4, null, null, 5]}
+        fontSize={[1, 2, 3, 4]}
         py={[1, null, null, null, null, null, null, null, null, 2]}
         px={[2, null, 3, 4, null, 4, null, null, null, 5]}
         mt={[2, null, null, null, 3, null, null, null, null, 4]}
         background="transparent"
         border={1}
         borderStyle="solid"
+        height="fit-content"
       >
         BUY THE MAG
       </Button>

--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -70,13 +70,12 @@ const BuyButton = () => {
         role="link"
         onClick={handleClick}
         fontSize={[1, 2, 3, 4]}
-        py={[1, null, null, null, null, null, null, null, null, 2]}
-        px={[2, null, 3, 4, null, 4, null, null, null, 5]}
-        mt={[2, null, null, null, 3, null, null, null, null, 4]}
         background="transparent"
         border={1}
         borderStyle="solid"
         height="fit-content"
+        py={1}
+        px={2}
       >
         BUY THE MAG
       </Button>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -10,6 +10,8 @@ import {
   SpaceProps,
   FlexboxProps,
   GridProps,
+  TypographyProps,
+  typography,
 } from "styled-system";
 import BuyButton from "./BuyButton";
 import NavMenu from "./NavMenu";
@@ -17,83 +19,59 @@ import oxymore from "./assets/home-page/oxymore.png";
 import manifesto from "./assets/home-page/manifesto.png";
 import number from "./assets/home-page/number-one.png";
 import alpha from "./assets/home-page/360_alpha.png";
+import Header from "./Header";
+import LanguageButtons from "./LanguageButtons";
 
-const Main = styled.main<SpaceProps & FlexboxProps & GridProps>`
-  background: black;
-  display: grid;
+const Main = styled.main<SpaceProps & FlexboxProps>`
+  display: flex;
   height: 100vh;
-  overflow: hidden;
   ${space};
-  ${flexbox}
-  ${grid};
+  ${flexbox};
 `;
 
-const Container = styled.div<
-  LayoutProps & FlexboxProps & GridProps & SpaceProps
->`
-  display: grid;
-  ${layout};
+const Row = styled.div<FlexboxProps & LayoutProps>`
+  display: flex;
   ${flexbox};
-  ${grid};
-  ${space};
+  ${layout};
 `;
 
-const PageLink = styled(NavLink)<
-  LayoutProps & FlexboxProps & GridProps & SpaceProps
->`
-  display: grid;
-  ${layout};
-  ${flexbox};
-  ${grid};
-  ${space};
+const PageLink = styled(NavLink)<TypographyProps>`
+  ${typography}
 `;
 
-const Img = styled.img<LayoutProps & FlexboxProps>`
-  ${layout};
-  ${flexbox};
+const Img = styled.img`
+  max-width: 30%;
 `;
 
 const Home = () => {
   return (
-    <Main
-      gridTemplateRows="repeat(3, 1fr)"
-      gridTemplateColumns="25% 50% 25%"
-      p={6}
-    >
-      <Container gridRow={1} gridColumn={1} gridTemplateRows="max-content">
-        <PageLink to="/">
-          <Img src={oxymore}></Img>
-        </PageLink>
-      </Container>
-      <Container
-        gridRow={1}
-        gridColumn={3}
-        gridTemplateRows="max-content"
-        gridTemplateColumns="max-content"
-        justifyContent="flex-end"
+    <Main p={6} flexDirection="column" justifyContent="space-between">
+      <Row
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
       >
-        <NavMenu />
-      </Container>
-      <Container
-        gridRow={2}
-        gridColumn={2}
-        alignSelf="center"
-        justifySelf="center"
-        width={["fit-content", null, null, null, null, null, null, null, "60%"]}
-      >
-        <PageLink to="/projects">
+        <Img src={oxymore}></Img>
+        <Row flexDirection="row" justifyContent="space-between">
+          <LanguageButtons />
+          <NavMenu />
+        </Row>
+      </Row>
+      <Row flexDirection="row">
+        <PageLink to="/projects" textAlign="center">
           <Img src={alpha}></Img>
         </PageLink>
-      </Container>
-      <Container gridRow={3} gridColumn={1} alignSelf="end" width="min-content">
-        <Img src={number} alignSelf="center" width="40%"></Img>
+      </Row>
+      <Row
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="flex-end"
+      >
         <BuyButton />
-      </Container>
-      <Container gridRow={3} gridColumn={3} alignSelf="end">
-        <PageLink to="/manifesto">
+        <PageLink to="/manifesto" textAlign="end">
           <Img src={manifesto}></Img>
         </PageLink>
-      </Container>
+      </Row>
     </Main>
   );
 };

--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -29,15 +29,15 @@ const LangButton = styled.button<SpaceProps & TypographyProps>`
 
 `;
 
-const LanguageButton = () => {
-  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
+const LanguageButtons = () => {
+  const fontSizes = [1, 2, 3, 4];
   const onLangClick = useCallback(
     (countryId: string) => () => i18next.changeLanguage(countryId),
     []
   );
 
   return (
-    <Container display="flex" flexDirection="row" mr={5}>
+    <Container display="flex" flexDirection="row" mr={8}>
       <LangButton onClick={onLangClick("en")} fontSize={fontSizes} mr={1}>
         EN
       </LangButton>
@@ -48,4 +48,4 @@ const LanguageButton = () => {
   );
 };
 
-export default LanguageButton;
+export default LanguageButtons;

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -89,11 +89,7 @@ const Link = ({ page, url }: LinkProps) => {
       gridTemplateColumns="max-content"
     >
       <MenuText>
-        <MenuLink
-          to={url}
-          color="black"
-          fontSize={[3, 4, 5, 6, null, 7, 9, 10]}
-        >
+        <MenuLink to={url} color="black">
           {page}
         </MenuLink>
       </MenuText>
@@ -103,8 +99,8 @@ const Link = ({ page, url }: LinkProps) => {
 
 const NavMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const fontSizes = [1, 2, 3, 4];
   const { t } = useTranslation();
-  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
   const Links: LinkProps[] = [
     {
       page: `${t("nav.about-us")}`,

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -43,7 +43,6 @@ const Logo = styled.p<PositionProps & TypographyProps>`
 const MenuButton = styled.button<
   TypographyProps & PositionProps & FlexboxProps & SpaceProps
 >`
-  display: grid;
   border: none;
   background: transparent;
   ${typography};
@@ -89,7 +88,7 @@ const Link = ({ page, url }: LinkProps) => {
       gridTemplateColumns="max-content"
     >
       <MenuText>
-        <MenuLink to={url} color="black">
+        <MenuLink to={url} color="black" fontSize={[5, 6, 7, 8]}>
           {page}
         </MenuLink>
       </MenuText>
@@ -126,11 +125,7 @@ const NavMenu = () => {
 
   return (
     <Fragment>
-      <MenuButton
-        onClick={() => setIsOpen(!isOpen)}
-        fontSize={fontSizes}
-        justifySelf="end"
-      >
+      <MenuButton onClick={() => setIsOpen(!isOpen)} fontSize={fontSizes}>
         MENU
       </MenuButton>
       <Overlay isOpen={isOpen}>

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -52,17 +52,7 @@ const colors = {
   activeShading: "rgba(27, 26, 33, 0.16)",
 };
 
-const breakpoints: string[] = [
-  "321px",
-  "361px",
-  "376px",
-  "412px",
-  "415px",
-  "426px",
-  "769px",
-  "1025px",
-  "1441px",
-];
+const breakpoints: string[] = ["319px", "424px", "767px", "1023px"];
 
 const fontSizes = {
   0: 10,


### PR DESCRIPTION
### What changes have you made?
- removes unused screen widths from the Theme
- applies updated font sizes to Homepage including Buy Button, Nav Menu and Language Buttons
- refactors Homepage from grid to flex 

### Which issue(s) does this PR fix?

Fixes #105 

### Screenshots (if there are design changes)
<img width="1440" alt="Screenshot 2020-08-06 at 22 01 31" src="https://user-images.githubusercontent.com/53219789/89577049-67d0fa00-d830-11ea-9ecc-c009f78f8bc5.png">

### How to test
- check the font sizes still look right on the different screen widths
- check everything remains in the correct place including the nav menu on click