### PR TITLE
reduces breakpoint usage and refactors using flex

### DIFF
--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -9,13 +9,15 @@ import {
   typography,
   border,
   background,
+  LayoutProps,
+  layout,
 } from "styled-system";
 import styled from "styled-components";
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
 
 const Button = styled.button<
-  SpaceProps & TypographyProps & BorderProps & BackgroundProps
+  SpaceProps & TypographyProps & BorderProps & BackgroundProps & LayoutProps
 >`
   width: auto;
   white-space: nowrap;
@@ -23,6 +25,7 @@ const Button = styled.button<
   ${typography};
   ${border};
   ${background};
+  ${layout};
 `;
 
 const stripePromise = loadStripe(`${process.env.REACT_APP_STRIPE_API_KEY}`);
@@ -66,13 +69,14 @@ const BuyButton = () => {
       <Button
         role="link"
         onClick={handleClick}
-        fontSize={[0, null, null, null, null, 1, 4, null, null, 5]}
-        py={[1, null, null, null, null, null, null, null, null, 2]}
-        px={[2, null, 3, 4, null, 4, null, null, null, 5]}
-        mt={[2, null, null, null, 3, null, null, null, null, 4]}
+        fontSize={[1, 2, 3, 4]}
         background="transparent"
         border={1}
         borderStyle="solid"
+        height="fit-content"
+        width="fit-content"
+        py={1}
+        px={2}
       >
         BUY THE MAG
       </Button>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -2,12 +2,10 @@ import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
-  color,
   space,
   typography,
   layout,
   flexbox,
-  ColorProps,
   SpaceProps,
   TypographyProps,
   LayoutProps,
@@ -17,24 +15,21 @@ import {
 const Main = styled.main<
   LayoutProps & FlexboxProps & SpaceProps & TypographyProps
 >`
-  background-color: black;
   display: flex;
-  min-height: 100vh;
   text-transform: uppercase;
+  height: 80vh;
   ${layout};
   ${flexbox};
   ${space};
   ${typography};
 `;
 
-const H1 = styled.h1<ColorProps & SpaceProps & TypographyProps>`
-  ${color};
+const H1 = styled.h1<SpaceProps & TypographyProps>`
   ${space};
   ${typography};
 `;
 
-const H2 = styled.h2<ColorProps & SpaceProps & TypographyProps>`
-  ${color};
+const H2 = styled.h2<SpaceProps & TypographyProps>`
   ${space};
   ${typography};
 `;
@@ -46,29 +41,22 @@ const ContactInfo = styled.p<SpaceProps & TypographyProps>`
 
 const Contact = () => {
   const { t } = useTranslation();
-
+  const fontSizes = [2, 3, 4, 5];
   return (
-    <Main
-      p={6}
-      display="flex"
-      alignItems="center"
-      textAlign={["center", "start"]}
-    >
+    <Main p={6} alignItems="center" textAlign={["center", "start"]}>
       <ul>
         <H1 fontSize={[4, 5, 6, 7]} py={3}>
           {t("contact.header")}
         </H1>
-        <H2 fontSize={[2, 3, 4, 5]} py={3}>
+        <H2 fontSize={fontSizes} py={3}>
           {t("contact.subheader")}
         </H2>
-        <ContactInfo fontSize={[2, 3, 4, 5]} py={1}>
+        <ContactInfo fontSize={fontSizes} py={1}>
           <a href="mailto:ox@oxymore.com" target="_blank">
             {t("contact.email")}
           </a>
         </ContactInfo>
-        <ContactInfo fontSize={[2, 3, 4, 5]}>
-          {t("contact.location")}
-        </ContactInfo>
+        <ContactInfo fontSize={fontSizes}>{t("contact.location")}</ContactInfo>
       </ul>
     </Main>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,15 +18,10 @@ import NavMenu from "./NavMenu";
 import LanguageButtons from "./LanguageButtons";
 import { NavLink, useLocation } from "react-router-dom";
 
-const HeaderContainer = styled.header<
-  LayoutProps & SpaceProps & GridProps & PositionProps & FlexboxProps
->`
+const HeaderContainer = styled.header<SpaceProps & FlexboxProps>`
   display: flex;
   width: 100%;
-  ${layout};
   ${space};
-  ${grid};
-  ${position};
   ${flexbox};
 `;
 
@@ -34,16 +29,12 @@ const H1 = styled.h1<SpaceProps & TypographyProps & GridProps>`
   ${typography};
 `;
 
-const Container = styled.div<
-  FlexboxProps & GridProps & LayoutProps & SpaceProps & TypographyProps
->`
-  ${flexbox};
-  ${grid};
+const Container = styled.div<LayoutProps>`
   ${layout};
 `;
 
 const HeaderLogo = () => {
-  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
+  const fontSizes = [1, 2, 3, 4];
 
   return (
     <NavLink to="/oxymore">

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -10,6 +10,8 @@ import {
   SpaceProps,
   FlexboxProps,
   GridProps,
+  TypographyProps,
+  typography,
 } from "styled-system";
 import BuyButton from "./BuyButton";
 import NavMenu from "./NavMenu";
@@ -18,82 +20,63 @@ import manifesto from "./assets/home-page/manifesto.png";
 import number from "./assets/home-page/number-one.png";
 import alpha from "./assets/home-page/360_alpha.png";
 
-const Main = styled.main<SpaceProps & FlexboxProps & GridProps>`
-  background: black;
-  display: grid;
+import LanguageButtons from "./LanguageButtons";
+
+const Main = styled.main<SpaceProps & FlexboxProps>`
+  display: flex;
   height: 100vh;
-  overflow: hidden;
   ${space};
-  ${flexbox}
-  ${grid};
+  ${flexbox};
 `;
 
-const Container = styled.div<
-  LayoutProps & FlexboxProps & GridProps & SpaceProps
->`
-  display: grid;
-  ${layout};
+const Row = styled.div<FlexboxProps & LayoutProps>`
+  display: flex;
   ${flexbox};
-  ${grid};
-  ${space};
+  ${layout};
 `;
 
-const PageLink = styled(NavLink)<
-  LayoutProps & FlexboxProps & GridProps & SpaceProps
->`
-  display: grid;
-  ${layout};
-  ${flexbox};
-  ${grid};
-  ${space};
+const PageLink = styled(NavLink)<TypographyProps>`
+  ${typography};
 `;
 
-const Img = styled.img<LayoutProps & FlexboxProps>`
+const Img = styled.img<LayoutProps & SpaceProps>`
+  max-width: 30%;
   ${layout};
-  ${flexbox};
+  ${space};
 `;
 
 const Home = () => {
   return (
-    <Main
-      gridTemplateRows="repeat(3, 1fr)"
-      gridTemplateColumns="25% 50% 25%"
-      p={6}
-    >
-      <Container gridRow={1} gridColumn={1} gridTemplateRows="max-content">
-        <PageLink to="/">
-          <Img src={oxymore}></Img>
-        </PageLink>
-      </Container>
-      <Container
-        gridRow={1}
-        gridColumn={3}
-        gridTemplateRows="max-content"
-        gridTemplateColumns="max-content"
-        justifyContent="flex-end"
+    <Main p={6} flexDirection="column" justifyContent="space-between">
+      <Row
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
       >
-        <NavMenu />
-      </Container>
-      <Container
-        gridRow={2}
-        gridColumn={2}
-        alignSelf="center"
-        justifySelf="center"
-        width={["fit-content", null, null, null, null, null, null, null, "60%"]}
-      >
-        <PageLink to="/projects">
+        <Img src={oxymore}></Img>
+        <Row flexDirection="row" justifyContent="space-between">
+          <LanguageButtons />
+          <NavMenu />
+        </Row>
+      </Row>
+      <Row flexDirection="row">
+        <PageLink to="/projects" textAlign="center">
           <Img src={alpha}></Img>
         </PageLink>
-      </Container>
-      <Container gridRow={3} gridColumn={1} alignSelf="end" width="min-content">
-        <Img src={number} alignSelf="center" width="40%"></Img>
-        <BuyButton />
-      </Container>
-      <Container gridRow={3} gridColumn={3} alignSelf="end">
-        <PageLink to="/manifesto">
-          <Img src={manifesto}></Img>
+      </Row>
+      <Row
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="flex-end"
+      >
+        <Row flexDirection="column">
+          <Img src={number} mb={3}></Img>
+          <BuyButton />
+        </Row>
+        <PageLink to="/manifesto" textAlign="end">
+          <Img src={manifesto} minWidth="50%"></Img>
         </PageLink>
-      </Container>
+      </Row>
     </Main>
   );
 };

--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -26,18 +26,17 @@ const LangButton = styled.button<SpaceProps & TypographyProps>`
   transition: transform 0.2s;
   &:hover {
     transform: scale(1.05);
-
 `;
 
-const LanguageButton = () => {
-  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
+const LanguageButtons = () => {
+  const fontSizes = [1, 2, 3, 4];
   const onLangClick = useCallback(
     (countryId: string) => () => i18next.changeLanguage(countryId),
     []
   );
 
   return (
-    <Container display="flex" flexDirection="row" mr={5}>
+    <Container display="flex" flexDirection="row" mr={8}>
       <LangButton onClick={onLangClick("en")} fontSize={fontSizes} mr={1}>
         EN
       </LangButton>
@@ -48,4 +47,4 @@ const LanguageButton = () => {
   );
 };
 
-export default LanguageButton;
+export default LanguageButtons;

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -13,8 +13,10 @@ import {
 } from "styled-system";
 
 const Main = styled.main<SpaceProps & FlexboxProps>`
-  min-height: 100vh;
+  display: flex;
+  height: 80vh;
   ${space};
+  ${flexbox};
 `;
 
 const Grid = styled.div<GridProps & FlexboxProps>`
@@ -23,11 +25,10 @@ const Grid = styled.div<GridProps & FlexboxProps>`
   ${flexbox};
 `;
 
-const H1 = styled.h1<TypographyProps & SpaceProps & GridProps>`
+const H1 = styled.h1<TypographyProps & SpaceProps>`
   text-transform: uppercase;
   ${typography};
   ${space};
-  ${grid};
 `;
 
 const Paragraph = styled.p<TypographyProps & SpaceProps>`
@@ -39,11 +40,11 @@ const Paragraph = styled.p<TypographyProps & SpaceProps>`
 
 const Manifesto = () => {
   const { t } = useTranslation();
-  const fontSizes = [1, 2, null, null, 2, 3, 4];
+  const fontSizes = [1, 2, 3, 4];
 
   return (
-    <Main p={8} mt={5}>
-      <H1 fontSize={[2, null, null, null, 3, 4, 5]} pb={5}>
+    <Main p={8} flexDirection="column" justifyContent="center">
+      <H1 fontSize={[2, 3, 4, 5]} pb={5}>
         {t("manifesto.header")}
       </H1>
       <Grid
@@ -51,10 +52,6 @@ const Manifesto = () => {
         gridColumnGap="2%"
         gridTemplateColumns={[
           "repeat(1, 100% [col-start])",
-          null,
-          null,
-          null,
-          null,
           null,
           null,
           "repeat(2, 49% [col-start])",

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -35,25 +35,14 @@ const Overlay = styled.dialog<{ isOpen: boolean }>`
   ${(props) => props.isOpen && overlayStyles}
 `;
 
-const Logo = styled.p<PositionProps & TypographyProps>`
-  ${position};
-  ${typography};
-`;
-
-const MenuButton = styled.button<
-  TypographyProps & PositionProps & FlexboxProps & SpaceProps
->`
-  display: grid;
+const MenuButton = styled.button<TypographyProps & PositionProps>`
   border: none;
   background: transparent;
   ${typography};
   ${position};
-  ${flexbox};
-  ${space};
 `;
 
-const MenuContainer = styled.div<SpaceProps & GridProps>`
-  ${space};
+const MenuContainer = styled.div<GridProps>`
   ${grid};
 `;
 
@@ -62,10 +51,10 @@ const Menu = styled.ul<GridProps & TypographyProps>`
   ${typography};
 `;
 
-const MenuLink = styled(NavLink)<ColorProps & TypographyProps>`
+const MenuLink = styled(NavLink)<ColorProps & TypographyProps & PositionProps>`
   ${color};
   ${typography};
-  }
+  ${position};
 `;
 
 const MenuText = styled.li`
@@ -89,11 +78,7 @@ const Link = ({ page, url }: LinkProps) => {
       gridTemplateColumns="max-content"
     >
       <MenuText>
-        <MenuLink
-          to={url}
-          color="black"
-          fontSize={[3, 4, 5, 6, null, 7, 9, 10]}
-        >
+        <MenuLink to={url} color="black" fontSize={[5, 6, 7, 8]}>
           {page}
         </MenuLink>
       </MenuText>
@@ -103,8 +88,8 @@ const Link = ({ page, url }: LinkProps) => {
 
 const NavMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const fontSizes = [1, 2, 3, 4];
   const { t } = useTranslation();
-  const fontSizes = [0, null, null, null, null, 1, 4, null, null, 5];
   const Links: LinkProps[] = [
     {
       page: `${t("nav.about-us")}`,
@@ -130,17 +115,21 @@ const NavMenu = () => {
 
   return (
     <Fragment>
-      <MenuButton
-        onClick={() => setIsOpen(!isOpen)}
-        fontSize={fontSizes}
-        justifySelf="end"
-      >
+      <MenuButton onClick={() => setIsOpen(!isOpen)} fontSize={fontSizes}>
         MENU
       </MenuButton>
       <Overlay isOpen={isOpen}>
-        <Logo fontSize={fontSizes} position="absolute" left={30} top={24}>
+        <MenuLink
+          to="/oxymore"
+          fontSize={fontSizes}
+          position="absolute"
+          left={30}
+          top={24}
+          color="black"
+          onClick={() => setIsOpen(!isOpen)}
+        >
           OXYMORE
-        </Logo>
+        </MenuLink>
 
         <MenuButton
           onClick={() => setIsOpen(false)}

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -52,17 +52,7 @@ const colors = {
   activeShading: "rgba(27, 26, 33, 0.16)",
 };
 
-const breakpoints: string[] = [
-  "321px",
-  "361px",
-  "376px",
-  "412px",
-  "415px",
-  "426px",
-  "769px",
-  "1025px",
-  "1441px",
-];
+const breakpoints: string[] = ["319px", "424px", "767px", "1023px"];
 
 const fontSizes = {
   0: 10,


### PR DESCRIPTION
### What changes have you made?

- removes unused screen widths from the Theme
- applies updated font sizes to Homepage including Buy Button, Nav Menu and Language Buttons 
- applies updated font sizes to Manifesto, Contact and Header
- reduces grid usage and applies flex on Homepage, Manifesto and Contact pages for a cleaner code

### Which issue(s) does this PR fix?

Fixes #105 

### Screenshots (if there are design changes)
<img width="1440" alt="Screenshot 2020-08-07 at 10 22 03" src="https://user-images.githubusercontent.com/53219789/89625319-f9278700-d897-11ea-90ca-d2b6cd0caa8a.png">

<img width="1440" alt="Screenshot 2020-08-07 at 10 22 47" src="https://user-images.githubusercontent.com/53219789/89625350-05abdf80-d898-11ea-9d96-46fdb42e1cb5.png">
<img width="1440" alt="Screenshot 2020-08-07 at 10 22 08" src="https://user-images.githubusercontent.com/53219789/89625336-004e9500-d898-11ea-9e3d-22ef90edc570.png">
<img width="1440" alt="Screenshot 2020-08-07 at 10 22 42" src="https://user-images.githubusercontent.com/53219789/89625341-02185880-d898-11ea-9eab-e449e1191419.png">

### How to test
- check the font sizes still look right on the different screen widths
- check everything remains in the correct place including the nav menu on click
- check there are no display bugs when navigating around the site 