### PR TITLE
adds negative number check to Timer to show 0 if time is up

### DIFF
--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -36,11 +36,16 @@ const Span = styled.span<SpaceProps>`
 const calculateTimeLeft = () => {
   let year = new Date().getFullYear();
   const difference = +new Date(`${year}-09-1`) - +new Date();
+  const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24));
+  const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24);
+  const minutesLeft = Math.floor((difference / 1000 / 60) % 60);
+  const secondsLeft = Math.floor((difference / 1000) % 60);
+
   const timeLeft = {
-    days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-    hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
-    minutes: Math.floor((difference / 1000 / 60) % 60),
-    seconds: Math.floor((difference / 1000) % 60),
+    days: daysLeft < 0 ? 0 : daysLeft,
+    hours: hoursLeft < 0 ? 0 : hoursLeft,
+    minutes: minutesLeft < 0 ? 0 : minutesLeft,
+    seconds: secondsLeft < 0 ? 0 : secondsLeft,
   };
 
   return timeLeft;


### PR DESCRIPTION
### What changes have you made?

- adds check to see if the timeLeft is less than 0, if it is return 0 for that time component

### Which issue(s) does this PR fix?

Fixes #112

### Screenshots (if there are design changes)
before:
![image](https://user-images.githubusercontent.com/11725595/92212395-33357a00-ee92-11ea-9123-285b94cad2b3.png)

after:
![image](https://user-images.githubusercontent.com/11725595/92212227-f23d6580-ee91-11ea-82c9-104291194711.png)


### How to test

- load up `localhost:3000` and should see 0 days instead of minus number etc...
