### PR TITLE
fixes title jump #123

### DIFF
--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -14,13 +14,14 @@ import {
 
 const Main = styled.main<SpaceProps & FlexboxProps>`
   display: flex;
-  height: 80vh;
+  min-height: 100vh;
   ${space};
   ${flexbox};
 `;
 
 const Grid = styled.div<GridProps & FlexboxProps>`
   display: grid;
+  height: 90%;
   ${grid};
   ${flexbox};
 `;
@@ -36,6 +37,7 @@ const Paragraph = styled.p<TypographyProps & SpaceProps>`
   ${typography};
   ${space};
   text-align: justify;
+  line-height: 1.5;
 `;
 
 const Manifesto = () => {
@@ -44,17 +46,17 @@ const Manifesto = () => {
 
   return (
     <Main p={8} flexDirection="column" justifyContent="center">
-      <H1 fontSize={[2, 3, 4, 5]} pb={5}>
+      <H1 fontSize={[2, 5]} pb={5}>
         {t("manifesto.header")}
       </H1>
       <Grid
         justifyContent="center"
-        gridColumnGap="2%"
+        gridColumnGap="4%"
         gridTemplateColumns={[
           "repeat(1, 100% [col-start])",
-          null,
-          null,
-          "repeat(2, 49% [col-start])",
+          "repeat(1, 100% [col-start])",
+          "repeat(2, 48% [col-start])",
+          "repeat(2, 48% [col-start])",
         ]}
       >
         <Paragraph pb={5} fontSize={fontSizes}>


### PR DESCRIPTION
### What changes have you made?

- added a fixed height to get rid of the title jump on changing screen size 
- created more space between the columns for better readability 

### Which issue(s) does this PR fix?

Fixes #123 

### Screenshots (if there are design changes)
<img width="1440" alt="Screenshot 2020-09-06 at 21 57 44" src="https://user-images.githubusercontent.com/53219789/92334193-1369a600-f08c-11ea-9db8-30d3b3ba9899.png">


### How to test
check the Manifesto page to see if there´s any jump in the content when dragging the screen size in and out in the browser
