### PR TITLE
Fixing homepage layout styles and button size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import Manifesto from "./components/Manifesto";
 import Header from "./components/Header";
 
 const AppContent = styled.div`
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 `;

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -2,11 +2,19 @@ import { createGlobalStyle } from "styled-components";
 import theme from "./components/theme";
 
 const GlobalStyle = createGlobalStyle`
+  html {
+    height: 100%;
+  }
   body {
+    min-height: 100%;
+    height: 100%;
     font-family: "Helvetica Neue";
     text-decoration: none;
     color: ${theme.colors.athensGray};
     background: ${theme.colors.black};
+  }
+  #root {
+    height: 100%;
   }
   button {
     cursor: pointer;

--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -78,14 +78,13 @@ const BuyButton: React.FC<BuyButtonProps> = (props) => {
         role="link"
         onClick={handleClick}
         fontSize={[0, 1, 3]}
-        p={[2, 3]}
         background="transparent"
         border={1}
         borderStyle="solid"
         height="fit-content"
         width="fit-content"
-        py={1}
-        px={2}
+        py={[1, 1, 2, 3]}
+        px={[1, 1, 2, 3]}
       >
         BUY THE MAG
       </Button>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -55,8 +55,8 @@ const ProjectsLink = styled(NavLink)<TypographyProps & FlexboxProps>`
 
   display: flex;
   align-self: center;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-start;
+  justify-content: flex-start;
   ${flexbox}
 `;
 const ProjectsImg = styled.img<LayoutProps & SpaceProps>`

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -22,7 +22,7 @@ import LanguageButtons from "./LanguageButtons";
 
 const Main = styled.main<SpaceProps & FlexboxProps>`
   display: flex;
-  height: 100vh;
+  height: 100%;
   ${space};
   ${flexbox};
 `;
@@ -32,12 +32,28 @@ const Flex = styled.div<FlexboxProps>`
   ${flexbox};
 `;
 
-const PageLink = styled(NavLink)<TypographyProps>`
+const ManifestoLink = styled(NavLink)<TypographyProps & FlexboxProps>`
   ${typography};
+
+  display: flex;
+  ${flexbox}
 `;
 
 const Img = styled.img<LayoutProps & SpaceProps>`
-  max-width: 30%;
+  height: 8vw;
+  align-self: flex-start;
+  ${layout};
+  ${space};
+`;
+
+const ProjectsLink = styled(NavLink)<TypographyProps & FlexboxProps>`
+  ${typography};
+
+  display: flex;
+  align-self: center;
+  ${flexbox}
+`;
+const ProjectsImg = styled.img<LayoutProps & SpaceProps>`
   ${layout};
   ${space};
 `;
@@ -46,28 +62,25 @@ const Home = () => {
   return (
     <Main p={6} flexDirection="column" justifyContent="space-between">
       <Flex justifyContent="space-between" alignItems="flex-start">
-        <Img src={oxymore}></Img>
+        <Img src={oxymore} />
         <Flex justifyContent="space-between">
           <LanguageButtons />
           <NavMenu />
         </Flex>
       </Flex>
 
-      <PageLink to="/projects" textAlign="center">
-        <Img src={alpha} width={500}></Img>
-      </PageLink>
+      <ProjectsLink to="/projects" textAlign="center">
+        <ProjectsImg src={alpha} width={500} />
+      </ProjectsLink>
 
       <Flex justifyContent="space-between" alignItems="flex-end">
         <Flex flexDirection="column">
-          <Img src={number} mb={3}></Img>
-          <BuyButton
-            successUrl={`${process.env.REACT_APP_BASE_URL}/oxymore`}
-            cancelUrl={`${process.env.REACT_APP_BASE_URL}/oxymore`}
-          />
+          <Img src={number} mb={3} height="4vw" />
+          <BuyButton />
         </Flex>
-        <PageLink to="/manifesto" textAlign="end">
-          <Img src={manifesto} minWidth="50%"></Img>
-        </PageLink>
+        <ManifestoLink to="/manifesto" alignItems="flex-end">
+          <Img src={manifesto} />
+        </ManifestoLink>
       </Flex>
     </Main>
   );

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -39,10 +39,14 @@ const ManifestoLink = styled(NavLink)<TypographyProps & FlexboxProps>`
   ${flexbox}
 `;
 
-const Img = styled.img<LayoutProps & SpaceProps>`
-  height: 8vw;
-  align-self: flex-start;
-  ${layout};
+const DoubleLineTextImage = styled.img`
+  height: 10vw;
+  max-height: 88px;
+`;
+const SingleLineTextImage = styled.img<SpaceProps>`
+  height: 5vw;
+  max-height: 44px;
+
   ${space};
 `;
 
@@ -51,35 +55,41 @@ const ProjectsLink = styled(NavLink)<TypographyProps & FlexboxProps>`
 
   display: flex;
   align-self: center;
+  align-items: center;
+  justify-content: center;
   ${flexbox}
 `;
 const ProjectsImg = styled.img<LayoutProps & SpaceProps>`
   ${layout};
   ${space};
+
+  max-width: 40vw;
+  max-height: 60vh;
 `;
 
 const Home = () => {
   return (
     <Main p={6} flexDirection="column" justifyContent="space-between">
       <Flex justifyContent="space-between" alignItems="flex-start">
-        <Img src={oxymore} />
+        <DoubleLineTextImage src={oxymore} />
         <Flex justifyContent="space-between">
           <LanguageButtons />
           <NavMenu />
         </Flex>
       </Flex>
-
-      <ProjectsLink to="/projects" textAlign="center">
-        <ProjectsImg src={alpha} width={500} />
+      <ProjectsLink to="/projects">
+        <ProjectsImg src={alpha} />
       </ProjectsLink>
-
       <Flex justifyContent="space-between" alignItems="flex-end">
-        <Flex flexDirection="column">
-          <Img src={number} mb={3} height="4vw" />
-          <BuyButton />
+        <Flex flexDirection="column" alignItems="flex-start">
+          <SingleLineTextImage src={number} mb={3} />
+          <BuyButton
+            successUrl={`${process.env.REACT_APP_BASE_URL}/oxymore`}
+            cancelUrl={`${process.env.REACT_APP_BASE_URL}/oxymore`}
+          />
         </Flex>
         <ManifestoLink to="/manifesto" alignItems="flex-end">
-          <Img src={manifesto} />
+          <DoubleLineTextImage src={manifesto} />
         </ManifestoLink>
       </Flex>
     </Main>


### PR DESCRIPTION
### What changes have you made?

- GlobalStyles
  - I've added `height: 100%` to body and html. This is because on an actual mobile phone, using 100vh leads to undesired scroll, because it uses the pixel height of the device, not the available screen space (which is diminished by the browser url bar etc etc)
  - see https://stackoverflow.com/questions/6654958/make-body-have-100-of-the-browser-height
  - see https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser
- Home.tsx
  - renames some components for clarity
  - fixes heights of text images
    - using `4vw` has the height of a single line. This is because in this case we really don't want the text to become too wide for the screen. By making the height of the text relative to the _width_ of the screen, we pretty much prevent this from happening.
    - if we think the image sizes are slightly off for some viewports, we can adjust this sizing.  
- BuyButton.tsx
  - removes redundant `p` padding attritbute
  - adds breakpoint values for `py` and `px` attributes

### Which issue(s) does this PR fix?

Fixes  #127 
Fixes #131

### Screenshots (if there are design changes)
![image](https://user-images.githubusercontent.com/12934669/92388653-8d8f3e80-f10f-11ea-8ca8-5b52825f63c6.png)
![image](https://user-images.githubusercontent.com/12934669/92388671-997b0080-f10f-11ea-8893-c66526c3c3e2.png)

### How to test
- Check home page on different viewport sizes 
