### PR TITLE
Adds cancelUrl and successUrl props to BuyButton 

### DIFF
--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -33,7 +33,12 @@ const Button = styled.button<
 
 const stripePromise = loadStripe(`${process.env.REACT_APP_STRIPE_API_KEY}`);
 
-const BuyButton = () => {
+interface BuyButtonProps {
+  successUrl: string;
+  cancelUrl: string;
+}
+const BuyButton: React.FC<BuyButtonProps> = (props) => {
+  const { successUrl, cancelUrl } = props;
   const [error, setError] = useState<string>();
 
   const handleClick = async () => {
@@ -52,8 +57,8 @@ const BuyButton = () => {
           },
         ],
         mode: "payment",
-        successUrl: `${process.env.REACT_APP_BASE_URL}/projects`,
-        cancelUrl: `${process.env.REACT_APP_BASE_URL}/projects`,
+        successUrl,
+        cancelUrl,
         shippingAddressCollection: {
           allowedCountries: ["ES", "FR", "GB"],
         },

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -60,7 +60,10 @@ const Home = () => {
       <Flex justifyContent="space-between" alignItems="flex-end">
         <Flex flexDirection="column">
           <Img src={number} mb={3}></Img>
-          <BuyButton />
+          <BuyButton
+            successUrl={`${process.env.REACT_APP_BASE_URL}/oxymore`}
+            cancelUrl={`${process.env.REACT_APP_BASE_URL}/oxymore`}
+          />
         </Flex>
         <PageLink to="/manifesto" textAlign="end">
           <Img src={manifesto} minWidth="50%"></Img>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -143,7 +143,10 @@ const Projects = () => {
         />
       </Container>
       <BuyButtonContainer position="fixed" top="50%" zIndex={zIndexes.inFront}>
-        <BuyButton />
+        <BuyButton
+          successUrl={`${process.env.REACT_APP_BASE_URL}/projects`}
+          cancelUrl={`${process.env.REACT_APP_BASE_URL}/projects`}
+        />
       </BuyButtonContainer>
 
       <Scrollback


### PR DESCRIPTION
### What changes have you made?

- adds `successUrl` and `cancelUrl` props to BuyButton

### Which issue(s) does this PR fix?

Fixes #128

### How to test
- click "Buy" from home page
- click "Back"
  - should be directed back to home page
- click "Buy" from projects page
- click "Back"
  - should be directed back to projects page