### PR TITLE
Fixes projects menu overlay 

### DIFF
--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -13,6 +13,8 @@ import {
   layout,
 } from "styled-system";
 import styled from "styled-components";
+
+import { zIndexes } from "./theme";
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
 
@@ -21,7 +23,7 @@ const Button = styled.button<
 >`
   width: auto;
   white-space: nowrap;
-  z-index: 2;
+  z-index: ${zIndexes.inFront};
   ${space};
   ${typography};
   ${border};

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -12,6 +12,7 @@ import {
   PositionProps,
   GridProps,
 } from "styled-system";
+import { zIndexes } from "./theme";
 
 const overlayStyles = css`
   display: flex;
@@ -24,6 +25,8 @@ const overlayStyles = css`
   background-size: cover;
   opacity: 1;
   top: 0;
+  position: fixed;
+  z-index: ${zIndexes.overlay};
 `;
 
 const Overlay = styled.dialog<{ isOpen: boolean }>`

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -26,6 +26,7 @@ import mask from "./assets/project-page/mask.png";
 import spider from "./assets/project-page/spider.png";
 import magnify from "./assets/project-page/magnify.png";
 import BuyButton from "./BuyButton";
+import { zIndexes } from "./theme";
 
 const Main = styled.main<PositionProps & FlexboxProps & LayoutProps>`
   display: flex;
@@ -141,7 +142,7 @@ const Projects = () => {
           justifySelf={["center", "center"]}
         />
       </Container>
-      <BuyButtonContainer position="fixed" top="50%" zIndex={1}>
+      <BuyButtonContainer position="fixed" top="50%" zIndex={zIndexes.inFront}>
         <BuyButton />
       </BuyButtonContainer>
 

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -9,6 +9,12 @@ export type Colors =
       accentPrimary: string;
     };
 
+export const zIndexes = {
+  behind: -1,
+  inFront: 1,
+  overlay: 1300,
+};
+
 const colorCodes = {
   // Core colors
   azure: "#306fb6",


### PR DESCRIPTION
### What changes have you made?

- adds `zIndexes` to theme.ts
- makes menu dialog `position: fixed;`

### Which issue(s) does this PR fix?

Fixes #122

### Screenshots (if there are design changes)
![image](https://user-images.githubusercontent.com/12934669/92396506-03e66d80-f11d-11ea-8142-301cb7aac8a4.png)

### How to test
- open menu from projects page
  - should function normally
