### PR TITLE
moves buy button to bottom of screen on desktop #129

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -45,8 +45,9 @@ const Container = styled.div<
   overflow: hidden;
 `;
 
-const BuyButtonContainer = styled.div<PositionProps>`
+const BuyButtonContainer = styled.div<PositionProps & SpaceProps>`
   ${position};
+  ${space};
 `;
 const Img = styled.img<LayoutProps & GridProps & FlexboxProps>`
   ${layout};
@@ -142,7 +143,12 @@ const Projects = () => {
           justifySelf={["center", "center"]}
         />
       </Container>
-      <BuyButtonContainer position="fixed" top="50%" zIndex={zIndexes.inFront}>
+      <BuyButtonContainer
+        position="fixed"
+        bottom={["40%", "40%", "0%", "0%"]}
+        p={6}
+        zIndex={zIndexes.inFront}
+      >
         <BuyButton
           successUrl={`${process.env.REACT_APP_BASE_URL}/projects`}
           cancelUrl={`${process.env.REACT_APP_BASE_URL}/projects`}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -53,6 +53,9 @@ const Img = styled.img<LayoutProps & GridProps & FlexboxProps>`
   ${layout};
   ${grid};
   ${flexbox};
+  transition: transform 0.2s;
+  &:hover {
+    transform: scale(1.05);
 `;
 type ScrollbackProps = PositionProps &
   TypographyProps &


### PR DESCRIPTION
### What changes have you made?

- moved buy button on projects page to bottom of screen after chat with Aitor 
- added hover styles to project icons 

### Which issue(s) does this PR fix?

Fixes #129 
Fixes #135

### Screenshots (if there are design changes)
<img width="1440" alt="Screenshot 2020-09-14 at 17 13 32" src="https://user-images.githubusercontent.com/53219789/93104062-acf90f00-f6ad-11ea-963f-5ab01c4535a0.png">


### How to test
- on the projects page check the buy button is at the bottom on desktop 
- on the projects page check the buy button is fixed to the middle on mobile