### PR TITLE
specifies button fonts #110

### DIFF
--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -20,7 +20,7 @@ const GlobalStyle = createGlobalStyle`
     cursor: pointer;
     color: ${theme.colors.athensGray};
     outline: none; 
-    font-family: "Helvetica Neue";
+    font-family: "Helvetica Neue", Sans-Serif;
   }
   a {
     text-decoration: none;

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -19,7 +19,8 @@ const GlobalStyle = createGlobalStyle`
   button {
     cursor: pointer;
     color: ${theme.colors.athensGray};
-    outline: none;
+    outline: none; 
+    font-family: "Helvetica Neue";
   }
   a {
     text-decoration: none;


### PR DESCRIPTION
### What changes have you made?

- added button fonts to `GlobalStyle` 
- added fallback font as per #109 

### Which issue(s) does this PR fix?

Fixes #110 

### Screenshots (if there are design changes)

<img width="596" alt="Screenshot 2020-09-18 at 12 40 21" src="https://user-images.githubusercontent.com/53219789/93588909-5b51cc80-f9ac-11ea-9aea-cf2aeb1aab5c.png">

### How to test
right click on any button on Dev Tools and check that the `Helvetica` font is correctly displaying as a property of the button tag