### PR TITLE
fixes nav menu on safari

### DIFF
--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -19,7 +19,7 @@ import { zIndexes } from "./theme";
 const overlayStyles = css`
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   justify-content: center;
   border: none;

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -27,6 +27,7 @@ const overlayStyles = css`
   background-size: cover;
   opacity: 1;
   top: 0;
+  right: 0;
   position: fixed;
   background-color: white;
   z-index: ${zIndexes.overlay};


### PR DESCRIPTION
### What changes have you made?
- added a CSS attribute of `right: 0` to offset the nav menu on safari 

### Which issue(s) does this PR fix?

Fixes #145 

### Screenshots (if there are design changes)

Before 

<img width="1440" alt="Screenshot 2020-09-18 at 12 32 45" src="https://user-images.githubusercontent.com/53219789/93588027-18432980-f9ab-11ea-8778-408eaae74f40.png">

After 
<img width="1440" alt="Screenshot 2020-09-22 at 12 21 09" src="https://user-images.githubusercontent.com/53219789/93870945-3623cd80-fcce-11ea-95e8-fb530fdeac49.png">

### How to test
- open up the nav menu on safari and check that the overlay covers the whole screen. 
- make sure the fix doesn't create any display issues on Chrome 