### PR TITLE
removes view heights #159

### DIFF
--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -61,7 +61,6 @@ const teamMembers: TeamMemberProps[] = [
 ];
 
 const Main = styled.main<SpaceProps>`
-  min-height: 100vh;
   ${space};
 `;
 

--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -62,6 +62,7 @@ const teamMembers: TeamMemberProps[] = [
 
 const Main = styled.main<SpaceProps>`
   ${space};
+  height: 100%;
 `;
 
 const Grid = styled.div<GridProps & FlexboxProps & SpaceProps>`

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -12,16 +12,16 @@ import {
   FlexboxProps,
 } from "styled-system";
 
-const Main = styled.main<
-  LayoutProps & FlexboxProps & SpaceProps & TypographyProps
->`
+const Main = styled.main<FlexboxProps>`
   display: flex;
-  text-transform: uppercase;
-  height: 80vh;
-  ${layout};
+  height: 100%;
   ${flexbox};
-  ${space};
+`;
+
+const Container = styled.div<TypographyProps & LayoutProps>`
   ${typography};
+  ${layout};
+  text-transform: uppercase;
 `;
 
 const H1 = styled.h1<SpaceProps & TypographyProps>`
@@ -43,25 +43,32 @@ const Contact = () => {
   const { t } = useTranslation();
   const fontSizes = [2, 3, 4, 5];
   return (
-    <Main alignItems="center" textAlign={["center", "start"]}>
-      <ul>
-        <H1 fontSize={[4, 5, 6, 7]} py={3}>
-          {t("contact.header")}
-        </H1>
-        <H2 fontSize={fontSizes} py={3}>
-          {t("contact.subheader")}
-        </H2>
-        <ContactInfo fontSize={fontSizes} py={1}>
-          <a
-            href="mailto:ox@oxymore.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t("contact.email")}
-          </a>
-        </ContactInfo>
-        <ContactInfo fontSize={fontSizes}>{t("contact.location")}</ContactInfo>
-      </ul>
+    <Main alignItems="center">
+      <Container
+        textAlign={["center", "center", "center", "justify"]}
+        height="50%"
+      >
+        <ul>
+          <H1 fontSize={[4, 5, 6, 7]} py={3}>
+            {t("contact.header")}
+          </H1>
+          <H2 fontSize={fontSizes} py={3}>
+            {t("contact.subheader")}
+          </H2>
+          <ContactInfo fontSize={fontSizes} py={1}>
+            <a
+              href="mailto:ox@oxymore.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t("contact.email")}
+            </a>
+          </ContactInfo>
+          <ContactInfo fontSize={fontSizes}>
+            {t("contact.location")}
+          </ContactInfo>
+        </ul>
+      </Container>
     </Main>
   );
 };

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -5,8 +5,8 @@ import { FlexboxProps, flexbox } from "styled-system";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
-  height: 100vh;
   overflow: hidden;
+  height: 100%;
   ${flexbox}
 `;
 

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -10,18 +10,23 @@ import {
   TypographyProps,
   FlexboxProps,
   GridProps,
+  LayoutProps,
+  layout,
 } from "styled-system";
 
 const Main = styled.main<SpaceProps & FlexboxProps>`
   display: flex;
-  min-height: 100vh;
+  height: 100%;
   ${space};
   ${flexbox};
 `;
 
+const Container = styled.div<LayoutProps>`
+  ${layout};
+`;
+
 const Grid = styled.div<GridProps & FlexboxProps>`
   display: grid;
-  height: 90%;
   ${grid};
   ${flexbox};
 `;
@@ -46,26 +51,28 @@ const Manifesto = () => {
 
   return (
     <Main flexDirection="column" justifyContent="center">
-      <H1 fontSize={[2, 5]} pb={5}>
-        {t("manifesto.header")}
-      </H1>
-      <Grid
-        justifyContent="center"
-        gridColumnGap="4%"
-        gridTemplateColumns={[
-          "repeat(1, 100% [col-start])",
-          "repeat(1, 100% [col-start])",
-          "repeat(2, 48% [col-start])",
-          "repeat(2, 48% [col-start])",
-        ]}
-      >
-        <Paragraph pb={5} fontSize={fontSizes}>
-          {t("manifesto.manifesto")}
-        </Paragraph>
-        <Paragraph pb={5} fontSize={fontSizes}>
-          {t("manifesto.manifesto")}
-        </Paragraph>
-      </Grid>
+      <Container height="75%">
+        <H1 fontSize={[2, 5]} pb={5}>
+          {t("manifesto.header")}
+        </H1>
+        <Grid
+          justifyContent="center"
+          gridColumnGap="4%"
+          gridTemplateColumns={[
+            "repeat(1, 100% [col-start])",
+            "repeat(1, 100% [col-start])",
+            "repeat(1, 100% [col-start])",
+            "repeat(2, 48% [col-start])",
+          ]}
+        >
+          <Paragraph pb={5} fontSize={fontSizes}>
+            {t("manifesto.manifesto")}
+          </Paragraph>
+          <Paragraph pb={5} fontSize={fontSizes}>
+            {t("manifesto.manifesto")}
+          </Paragraph>
+        </Grid>
+      </Container>
     </Main>
   );
 };

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -30,6 +30,7 @@ import { zIndexes } from "./theme";
 
 const Main = styled.main<PositionProps & FlexboxProps & LayoutProps>`
   display: flex;
+  height: 100%;
   ${position};
   ${flexbox};
 `;
@@ -86,7 +87,7 @@ const Projects = () => {
       <Container
         gridTemplateColumns="repeat(3, 1fr)"
         display="grid"
-        height="100%"
+        height="80%"
       >
         <Img
           src={stairs}


### PR DESCRIPTION
### What changes have you made?
- removed `vh` usage in all of the `main` tags and replaced with `height: 100%` 
- although there is a `height: 100%` in the `body` class of Global Style, it wasn't showing as inherited on some of the components so for consistency that's why I've kept an attribute of `height: 100%` on each of the `Main` tags
- where `height: 100%` is a bit high, I've wrapped some components in a `Container` in order to set height as a % of the `Main` 

### Which issue(s) does this PR fix?

Fixes #159 

### Screenshots (if there are design changes)

### How to test
- check for any unused `vh` attributes
- move through the site and check that the height of each page looks consistent 