### PR TITLE
creates active button styles #43

### DIFF
--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -39,7 +39,7 @@ const ActiveLang = css`
 const LanguageButtons = () => {
   const fontSizes = [1, 2, 3, 4];
 
-  const [activeLang, setActiveLang] = useState<String>();
+  const [activeLang, setActiveLang] = useState<string>();
 
   const onLangClick = useCallback(
     (countryId: string) => () => {

--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -39,12 +39,12 @@ const ActiveLang = css`
 const LanguageButtons = () => {
   const fontSizes = [1, 2, 3, 4];
 
-  const [activeLang, setActiveLang] = useState();
+  const [activeLang, setActiveLang] = useState<String>();
 
   const onLangClick = useCallback(
     (countryId: string) => () => {
       i18next.changeLanguage(countryId);
-      setActiveLang(activeLang);
+      setActiveLang(countryId);
     },
     []
   );

--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -39,12 +39,12 @@ const ActiveLang = css`
 const LanguageButtons = () => {
   const fontSizes = [1, 2, 3, 4];
 
-  const [activeLang, setActiveLang] = useState(i18next.language);
+  const [activeLang, setActiveLang] = useState();
 
   const onLangClick = useCallback(
     (countryId: string) => () => {
       i18next.changeLanguage(countryId);
-      setActiveLang(countryId);
+      setActiveLang(activeLang);
     },
     []
   );

--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from "react";
-import styled from "styled-components";
+import React, { useCallback, useState } from "react";
+import styled, { css } from "styled-components";
 import {
   space,
   typography,
@@ -18,7 +18,9 @@ const Container = styled.div<FlexboxProps & LayoutProps & SpaceProps>`
   ${space};
 `;
 
-const LangButton = styled.button<SpaceProps & TypographyProps>`
+const LangButton = styled.button<
+  SpaceProps & TypographyProps & { isActive: boolean }
+>`
   background: transparent;
   border: none;
   ${typography};
@@ -26,14 +28,20 @@ const LangButton = styled.button<SpaceProps & TypographyProps>`
   transition: transform 0.2s;
   &:hover {
     transform: scale(1.05);
+    ${(props) => props.isActive && ActiveButton}
+`;
+
+const ActiveButton = css`
+  text-decoration-line: underline;
 `;
 
 const LanguageButtons = () => {
   const fontSizes = [1, 2, 3, 4];
+  const [isActive, setIsActive] = useState(false);
   const onLangClick = useCallback(
     (countryId: string) => () => i18next.changeLanguage(countryId),
     []
-  );
+  ) && setIsActive(!isActive)};
 
   return (
     <Container display="flex" flexDirection="row" mr={8}>

--- a/src/components/LanguageButtons.tsx
+++ b/src/components/LanguageButtons.tsx
@@ -26,29 +26,45 @@ const LangButton = styled.button<
   ${typography};
   ${space};
   transition: transform 0.2s;
+  ${(props) => props.isActive && ActiveLang}
   &:hover {
     transform: scale(1.05);
-    ${(props) => props.isActive && ActiveButton}
+  
 `;
 
-const ActiveButton = css`
+const ActiveLang = css`
   text-decoration-line: underline;
 `;
 
 const LanguageButtons = () => {
   const fontSizes = [1, 2, 3, 4];
-  const [isActive, setIsActive] = useState(false);
+
+  const [activeLang, setActiveLang] = useState(i18next.language);
+
   const onLangClick = useCallback(
-    (countryId: string) => () => i18next.changeLanguage(countryId),
+    (countryId: string) => () => {
+      i18next.changeLanguage(countryId);
+      setActiveLang(countryId);
+    },
     []
-  ) && setIsActive(!isActive)};
+  );
 
   return (
     <Container display="flex" flexDirection="row" mr={8}>
-      <LangButton onClick={onLangClick("en")} fontSize={fontSizes} mr={1}>
+      <LangButton
+        onClick={onLangClick("en")}
+        fontSize={fontSizes}
+        mr={1}
+        isActive={activeLang === "en"}
+      >
         EN
       </LangButton>
-      <LangButton onClick={onLangClick("es")} fontSize={fontSizes} ml={1}>
+      <LangButton
+        onClick={onLangClick("es")}
+        fontSize={fontSizes}
+        ml={1}
+        isActive={activeLang === "es"}
+      >
         ES
       </LangButton>
     </Container>


### PR DESCRIPTION
### What changes have you made?
- I want to give state to the active language button and display a small underscore to show the user which language is currently active
- Currently we're using one Hook on the top level of the component:

`const onLangClick = useCallback(
    (countryId: string) => () => i18next.changeLanguage(countryId),
    []
  );`

- I've added in `const [isActive, setIsActive] = useState(false);` at the top level too. This is how I was going to conditionally display the CSS styles passed in from the `ActiveButton` component to show the user which language is active.

My question is, how to apply more than one Hook to an `onClick` event. Intuitively this feels wrong. I've not found much online so I think I'm looking at this through the wrong lens.

My next idea was to declare the two hooks separately at the top level and wrap both in to a single `const` which can then be assigned to the `onClick` as normal. I didn't quite manage this either though.

Anyone able to steer me back on to the right track? Although it's a small CSS change, I think these problems are really pushing me to keep going with Hooks. Tricky to understand but starting to see the usability.  


### What changes have you made? [with solution]
- given state to the two language buttons to display a small underscore so that the user knows which one is currently active 

### Which issue(s) does this PR fix?

Fixes #43 

### Screenshots (if there are design changes)

<img width="316" alt="Screenshot 2020-09-28 at 11 49 28" src="https://user-images.githubusercontent.com/53219789/94417690-afb13500-0180-11eb-881e-4ba44f1af998.png">


### How to test
- toggle the two language buttons as you move through the site and check that the underscore displays under the active language
