### PR TITLE
adds icons to project pages #164

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import LeoAdef from "./components/project-pages/LeoAdef";
 import EroticStories from "./components/project-pages/EroticStories";
 import Map from "./components/project-pages/Map";
 import KaiLandre from "./components/project-pages/KaiLandre";
+import FashionEditorial from "./components/project-pages/FashionEditorial";
 
 const AppContent = styled.div`
   height: 100%;
@@ -46,6 +47,7 @@ const App = () => {
               <Route path="/leo-adef" exact component={LeoAdef} />
               <Route path="/the-map" exact component={Map} />
               <Route path="/kai-landre" exact component={KaiLandre} />
+              <Route path="/editorial" exact component={FashionEditorial} />
               <Route
                 path="/conscious-shopping"
                 exact

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -157,7 +157,7 @@ const Projects = () => {
         <ProjectLink
           to="leo-adef"
           gridColumn={[2, 2, 2, 2, 2]}
-          gridRow={[8, 8, 8, 8, 3]}
+          gridRow={[8, 8, 8, 8, "2/4"]}
           maxWidth={iconSizes}
           justifySelf="center"
         >
@@ -175,7 +175,7 @@ const Projects = () => {
       </Container>
       <BuyButtonContainer
         position="fixed"
-        bottom={["40%", "40%", "40%", "40%", "10%"]}
+        bottom={["40%", "40%", "40%", "40%", "15%"]}
         zIndex={zIndexes.inFront}
       >
         <BuyButton

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -79,6 +79,8 @@ const Projects = () => {
     window.scrollTo(0, 0);
   }, []);
 
+  const iconSizes = ["100%", "100%", "100%", "100%", "30%"];
+
   return (
     <Main justifyContent="center" alignItems="center">
       <Container
@@ -93,93 +95,87 @@ const Projects = () => {
           to="/editorial"
           gridColumn={[2, 2, 2, 2, 3]}
           gridRow={[1, 1, 1, 1, 1]}
+          justifySelf="start"
+          maxWidth={iconSizes}
         >
-          <Img
-            src={stairs}
-            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-          />
+          <Img src={stairs} />
         </ProjectLink>
         <ProjectLink
           to="/conscious-shopping"
           gridColumn={[2, 2, 2, 2, 2]}
           gridRow={[2, 2, 2, 2, "1/3"]}
-          justifyContent="center"
+          justifySelf="start"
+          maxWidth={iconSizes}
         >
-          <Img src={shell} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+          <Img src={shell} />
         </ProjectLink>
         <ProjectLink
           to="/eyes"
           gridColumn={[2, 2, 2, 2, 1]}
           gridRow={[3, 3, 3, 3, 1]}
-          justifyContent="center"
+          justifySelf="center"
+          maxWidth={iconSizes}
         >
-          <Img src={eye} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+          <Img src={eye} />
         </ProjectLink>
         <ProjectLink
           to="/erotic-stories"
           gridColumn={[2, 2, 2, 2, 1]}
           gridRow={[4, 4, 4, 4, 3]}
-          justifyContent="center"
+          justifySelf="center"
+          maxWidth={iconSizes}
         >
-          <Img
-            src={statue}
-            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-          />
+          <Img src={statue} />
         </ProjectLink>
         <ProjectLink
           to="kai-landre"
           gridColumn={[2, 2, 2, 2, 1]}
           gridRow={[5, 5, 5, 5, "2/4"]}
-          alignSelf="start"
-          justifyContent="flex-end"
+          justifySelf="end"
+          maxWidth={iconSizes}
         >
-          <Img
-            src={dragon}
-            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-          />
+          <Img src={dragon} />
         </ProjectLink>
         <ProjectLink
           to="/belledejour"
           gridColumn={[2, 2, 2, 2, 3]}
           gridRow={[6, 6, 6, 6, 3]}
+          maxWidth={iconSizes}
+          justifySelf="start"
         >
-          <Img src={knife} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+          <Img src={knife} />
         </ProjectLink>
         <ProjectLink
           to="marc-medina"
           gridColumn={[2, 2, 2, 2, 3]}
           gridRow={[7, 7, 7, 7, 2]}
-          alignSelf="flex-end"
-          justifyContent="center"
+          justifySelf="center"
+          maxWidth={iconSizes}
         >
-          <Img src={mask} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+          <Img src={mask} />
         </ProjectLink>
         <ProjectLink
           to="leo-adef"
           gridColumn={[2, 2, 2, 2, 2]}
           gridRow={[8, 8, 8, 8, 3]}
+          maxWidth={iconSizes}
+          justifySelf="center"
         >
-          <Img
-            src={spider}
-            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-          />
+          <Img src={spider} />
         </ProjectLink>
         <ProjectLink
           to="/the-map"
           gridColumn={[2, 2, 2, 2, 2]}
-          gridRow={[9, 9, 9, 9, "2/4"]}
-          justifyContent="flex-end"
+          gridRow={[9, 9, 9, 9, 2]}
+          justifySelf="end"
+          maxWidth={iconSizes}
         >
-          <Img
-            src={magnify}
-            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-          />
+          <Img src={magnify} />
         </ProjectLink>
       </Container>
       <BuyButtonContainer
         position="fixed"
         bottom={["40%", "40%", "40%", "40%", "10%"]}
-        p={6}
         zIndex={zIndexes.inFront}
       >
         <BuyButton

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -27,6 +27,7 @@ import spider from "./assets/project-page/spider-720.png";
 import magnify from "./assets/project-page/magnify-720.png";
 import BuyButton from "./BuyButton";
 import { zIndexes } from "./theme";
+import { Link } from "react-router-dom";
 
 const Main = styled.main<FlexboxProps & LayoutProps>`
   display: flex;
@@ -45,13 +46,21 @@ const BuyButtonContainer = styled.div<PositionProps & SpaceProps>`
   ${position};
   ${space};
 `;
-const Img = styled.img<LayoutProps & GridProps>`
+
+const ProjectLink = styled(Link)<LayoutProps & GridProps & FlexboxProps>`
   ${layout};
   ${grid};
+  ${flexbox};
+  display: flex;
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
   transition: transform 0.2s;
   &:hover {
     transform: scale(1.05);
 `;
+
 type ScrollbackProps = PositionProps &
   TypographyProps &
   BackgroundProps &
@@ -78,62 +87,94 @@ const Projects = () => {
         display="grid"
         justifyItems="center"
         alignItems="center"
-        height="85%"
+        height={["90%", "100%"]}
       >
-        <Img
-          src={stairs}
+        <ProjectLink
+          to="/editorial"
           gridColumn={[2, 2, 2, 2, 3]}
-          gridRow={[1, 1, 1, 1, "1/3"]}
-          maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-        />
-        <Img
-          src={shell}
-          gridColumn={[2, 2, 2, 2, "2/4"]}
-          gridRow={[2, 2, 2, 2, 1]}
-          maxWidth={["100%", "100%", "100%", "100%", "15%"]}
-        />
-        <Img
-          src={eye}
+          gridRow={[1, 1, 1, 1, 1]}
+        >
+          <Img
+            src={stairs}
+            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
+          />
+        </ProjectLink>
+        <ProjectLink
+          to="/conscious-shopping"
+          gridColumn={[2, 2, 2, 2, 2]}
+          gridRow={[2, 2, 2, 2, "1/3"]}
+          justifyContent="center"
+        >
+          <Img src={shell} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+        </ProjectLink>
+        <ProjectLink
+          to="/eyes"
           gridColumn={[2, 2, 2, 2, 1]}
           gridRow={[3, 3, 3, 3, 1]}
-          maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-        />
-        <Img
-          src={statue}
+          justifyContent="center"
+        >
+          <Img src={eye} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+        </ProjectLink>
+        <ProjectLink
+          to="/erotic-stories"
           gridColumn={[2, 2, 2, 2, 1]}
-          gridRow={[4, 4, 4, 4, "2/4"]}
-          maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-        />
-        <Img
-          src={dragon}
-          gridColumn={[2, 2, 2, 2]}
-          gridRow={[5, 5, 5, 5, 2]}
-          maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-        />
-        <Img
-          src={knife}
+          gridRow={[4, 4, 4, 4, 3]}
+          justifyContent="center"
+        >
+          <Img
+            src={statue}
+            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
+          />
+        </ProjectLink>
+        <ProjectLink
+          to="kai-landre"
+          gridColumn={[2, 2, 2, 2, 1]}
+          gridRow={[5, 5, 5, 5, "2/4"]}
+          alignSelf="start"
+          justifyContent="flex-end"
+        >
+          <Img
+            src={dragon}
+            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
+          />
+        </ProjectLink>
+        <ProjectLink
+          to="/belledejour"
           gridColumn={[2, 2, 2, 2, 3]}
           gridRow={[6, 6, 6, 6, 3]}
-          maxWidth={["100%", "100%", "100%", "100%", "30%"]}
-        />
-        <Img
-          src={mask}
-          gridColumn={[2, 2, 2, 2, "1/3"]}
-          gridRow={[7, 7, 7, 7, "1/3"]}
-          maxWidth={["100%", "100%", "100%", "100%", "15%"]}
-        />
-        <Img
-          src={spider}
-          gridColumn={[2, 2, 2, 2, "1/3"]}
+        >
+          <Img src={knife} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+        </ProjectLink>
+        <ProjectLink
+          to="marc-medina"
+          gridColumn={[2, 2, 2, 2, 3]}
+          gridRow={[7, 7, 7, 7, 2]}
+          alignSelf="flex-end"
+          justifyContent="center"
+        >
+          <Img src={mask} maxWidth={["100%", "100%", "100%", "100%", "30%"]} />
+        </ProjectLink>
+        <ProjectLink
+          to="leo-adef"
+          gridColumn={[2, 2, 2, 2, 2]}
           gridRow={[8, 8, 8, 8, 3]}
-          maxWidth={["100%", "100%", "100%", "100%", "15%"]}
-        />
-        <Img
-          src={magnify}
-          gridColumn={[2, 2, 2, 2, "2/4"]}
-          gridRow={[9, 9, 9, 9, 3]}
-          maxWidth={["100%", "100%", "100%", "100%", "15%"]}
-        />
+        >
+          <Img
+            src={spider}
+            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
+          />
+        </ProjectLink>
+        <ProjectLink
+          to="/the-map"
+          gridColumn={[2, 2, 2, 2, 2]}
+          gridRow={[9, 9, 9, 9, "2/4"]}
+          justifyContent="flex-end"
+        >
+          <Img
+            src={magnify}
+            maxWidth={["100%", "100%", "100%", "100%", "30%"]}
+          />
+        </ProjectLink>
       </Container>
       <BuyButtonContainer
         position="fixed"

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -23,19 +23,13 @@ const Container = styled.div<FlexboxProps & SpaceProps & TypographyProps>`
   display: flex;
 `;
 
-const H1 = styled.h1<TypographyProps & FlexboxProps>`
+const H1 = styled.h1<TypographyProps>`
   ${typography};
-  ${flexbox};
-  display: flex;
-`;
-
-const Span = styled.span<SpaceProps>`
-  ${space}
 `;
 
 const getInterval = (number: number, intervalType: string) => {
   const label = number === 1 ? intervalType : `${intervalType}`;
-  return `${number} ${label}`;
+  return `${number}${label}`;
 };
 
 interface TimerProps {
@@ -73,15 +67,13 @@ const Timer: React.FC<TimerProps> = (props) => {
   return (
     <Fragment>
       <Container alignItems="center" textAlign="center" p={6}>
-        <H1
-          fontSize={8}
-          fontFamily="SangBleu OG Serif Light"
-          flexDirection={["column", "column", "column", "column", "row"]}
-        >
-          <Span>{getInterval(timeLeft.days, "d")}</Span>
-          <Span>{getInterval(timeLeft.hours, "h")}</Span>
-          <Span>{getInterval(timeLeft.minutes, "m")}</Span>
-          <Span>{getInterval(timeLeft.seconds, "s")}</Span>
+        <H1 fontSize={[4, 5, 6, 8]} fontFamily="SangBleu OG Serif Light">
+          <span>
+            {getInterval(timeLeft.days, "d")}
+            {getInterval(timeLeft.hours, "h")}
+            {getInterval(timeLeft.minutes, "m")}
+            {getInterval(timeLeft.seconds, "s")}
+          </span>
         </H1>
       </Container>
     </Fragment>

--- a/src/components/project-pages/Belledejour.tsx
+++ b/src/components/project-pages/Belledejour.tsx
@@ -1,18 +1,33 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, LayoutProps, layout } from "styled-system";
+import knife from "../assets/project-page/knife-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const Belledejour = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        {" "}
+        <Img src={knife} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/ConsciousShopping.tsx
+++ b/src/components/project-pages/ConsciousShopping.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import shell from "../assets/project-page/shell-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const ConsciousShopping = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={shell} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/EroticStories.tsx
+++ b/src/components/project-pages/EroticStories.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import statue from "../assets/project-page/statue-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const EroticStories = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={statue} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/Eye.tsx
+++ b/src/components/project-pages/Eye.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import eye from "../assets/project-page/eye-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const Eye = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={eye} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/FashionEditorial.tsx
+++ b/src/components/project-pages/FashionEditorial.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import stairs from "../assets/project-page/stairs-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const FashionEditorial = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={stairs} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/KaiLandre.tsx
+++ b/src/components/project-pages/KaiLandre.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import dragon from "../assets/project-page/dragon-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const KaiLandre = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={dragon} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/LeoAdef.tsx
+++ b/src/components/project-pages/LeoAdef.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import spider from "../assets/project-page/spider-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const LeoAdef = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={spider} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/Map.tsx
+++ b/src/components/project-pages/Map.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import magnify from "../assets/project-page/magnify-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const Map = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={magnify} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );

--- a/src/components/project-pages/MarcMedina.tsx
+++ b/src/components/project-pages/MarcMedina.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox } from "styled-system";
+import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import mask from "../assets/project-page/mask-720.png";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100vh;
   overflow: hidden;
+  flex-direction: column;
   ${flexbox}
+`;
+
+const Container = styled.div<FlexboxProps>`
+  display: flex;
+  ${flexbox};
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
 `;
 
 const MarcMedina = () => {
   return (
-    <Main justifyContent="center">
+    <Main justifyContent="center" alignItems="center">
+      <Container justifyContent="center" alignItems="center">
+        <Img src={mask} maxWidth="30%" />
+      </Container>
       <Timer endDate="2020-11-20" />
     </Main>
   );


### PR DESCRIPTION
### What changes have you made?

- I've added icons to each of the project pages 
- I've linked the icons on the `Projects` component to each of the project pages
- On the `Projects` component, I had to introduce some `flexbox` props to offset any automatic repositioning on the grid caused by nesting of the `img` tags - by nesting I mean `<Link><img/></Link>`
- I added the `FashionEditorial` component to `App.tsx` because it was missing
- I removed some unused props from the `Timer` component 
- (As requested by Aitor) I've updated the `Timer` to replicate the original design here:

![01002d11-1a17-42f3-9a62-9920a65c2365 2](https://user-images.githubusercontent.com/53219789/94833715-bf927880-040f-11eb-88c5-89ce618ab1ab.JPG)


### Which issue(s) does this PR fix?

Fixes #164 

### Screenshots (if there are design changes)
<img width="229" alt="Screenshot 2020-10-01 at 18 03 27" src="https://user-images.githubusercontent.com/53219789/94834288-7b53a800-0410-11eb-861d-afbc83b99134.png">
<img width="1414" alt="Screenshot 2020-10-01 at 18 02 23" src="https://user-images.githubusercontent.com/53219789/94835152-95da5100-0411-11eb-8466-c10c07743ea7.png">


### How to test
check that each of the icons on the `Projects` component click through to its own "loading" page 

nb. ignore the dates on the timers for now as we're still waiting for the final schedule