### PR TITLE
updates manifesto text #166

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -15,12 +15,12 @@
     "email": "ox@oxymore.com",
     "location": "Barcelona"
   },
+  "manifesto": {
+    "header": "Manifesto",
+    "manifesto": "Classy anarchist connections make for genuinely diverse utopias in which noble social fights by minorities educate the ignorant and empower the humble and naïf. An oniric queer love revolution, elegantly kitsch and subtly absurd. An anti design dystopia created by aesthetic oxymorons."
+  },
   "about": {
     "header": "About",
     "subheader": "Oxymore is a biannual publication bla bla bla bla"
-  },
-  "manifesto": {
-    "header": "Manifesto",
-    "manifesto": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -17,7 +17,7 @@
   },
   "manifesto": {
     "header": "Manifiesto",
-    "manifesto": "Lorem Ipsum es simplemente el texto de relleno de las imprentas y archivos de texto. Lorem Ipsum ha sido el texto de relleno estándar de las industrias desde el año 1500, cuando un impresor (N. del T. persona que se dedica a la imprenta) desconocido usó una galería de textos y los mezcló de tal manera que logró hacer un libro de textos especimen. No sólo sobrevivió 500 años, sino que tambien ingresó como texto de relleno en documentos electrónicos, quedando esencialmente igual al original. Fue popularizado en los 60s con la creación de las hojas Letraset, las cuales contenian pasajes de Lorem Ipsum, y más recientemente con software de autoedición, como por ejemplo Aldus PageMaker, el cual incluye versiones de Lorem Ipsum."
+    "manifesto": "Conexiones anarquistas distinguidas crean utopías genuinamente diversas en las que las nobles luchas sociales de las minorías educan a los ignorantes y dan poder a los humildes e ingenuos. Una onírica revolución de amor queer, elegantemente kitsch y sutilmente absurda. Una distopía anti-diseño creada por oximoron estéticos."
   },
   "about": {
     "header": "Sobre nosotros",

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -21,8 +21,9 @@ const Main = styled.main<SpaceProps & FlexboxProps>`
   ${flexbox};
 `;
 
-const Container = styled.div<LayoutProps>`
+const Container = styled.div<LayoutProps & SpaceProps>`
   ${layout};
+  ${space};
 `;
 
 const Grid = styled.div<GridProps & FlexboxProps>`
@@ -47,31 +48,18 @@ const Paragraph = styled.p<TypographyProps & SpaceProps>`
 
 const Manifesto = () => {
   const { t } = useTranslation();
-  const fontSizes = [1, 2, 3, 4];
+  const fontSizes = [3, 4, 5, 5];
 
   return (
     <Main flexDirection="column" justifyContent="center">
-      <Container height="75%">
-        <H1 fontSize={[2, 5]} pb={5}>
+      <Container minHeight="50%" maxHeight="80%">
+        <H1 fontSize={[4, 5, 6, 6]} pb={5}>
           {t("manifesto.header")}
         </H1>
-        <Grid
-          justifyContent="center"
-          gridColumnGap="4%"
-          gridTemplateColumns={[
-            "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(1, 100% [col-start])",
-            "repeat(2, 48% [col-start])",
-          ]}
-        >
-          <Paragraph pb={5} fontSize={fontSizes}>
-            {t("manifesto.manifesto")}
-          </Paragraph>
-          <Paragraph pb={5} fontSize={fontSizes}>
-            {t("manifesto.manifesto")}
-          </Paragraph>
-        </Grid>
+
+        <Paragraph pb={5} fontSize={fontSizes}>
+          {t("manifesto.manifesto")}
+        </Paragraph>
       </Container>
     </Main>
   );


### PR DESCRIPTION
### What changes have you made?
- I've replaced the placeholder text with the approved Manifesto copy 
- I've had to increase the fonts and remove the <Grid> layout to minimise blank space 
- If you don't like the large font that's fine, it was a design choice more than anything else - I can bring it down a bit or increase the Header text ever so slightly if there's too much of a jump

### Which issue(s) does this PR fix?

Fixes #166

### Screenshots (if there are design changes)
<img width="280" alt="Screenshot 2020-10-02 at 12 43 55" src="https://user-images.githubusercontent.com/53219789/94916212-8ceb8d00-04ae-11eb-9594-fcc04bb507f4.png">

<img width="1431" alt="Screenshot 2020-10-02 at 12 44 41" src="https://user-images.githubusercontent.com/53219789/94916214-8e1cba00-04ae-11eb-8da9-f4bac2552d13.png">

### How to test
Check the Manifesto page to make sure the translation still works and that the font sizes are responsive on different mobile devices