### PR TITLE
adds static.json to force https

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,0 +1,7 @@
+{
+  "root": "build/",
+  "routes": {
+    "/**": "index.html"
+  },
+  "https_only": true
+}


### PR DESCRIPTION
follows https://stackoverflow.com/questions/48879408/why-cannot-i-redirect-my-react-app-on-heroku-from-http-to-https