### PR TITLE
fixes projects page on safari 

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -52,6 +52,7 @@ const ProjectLink = styled(Link)<LayoutProps & GridProps & FlexboxProps>`
   ${grid};
   ${flexbox};
   display: flex;
+  align-items: center;
 `;
 
 const Img = styled.img<LayoutProps>`


### PR DESCRIPTION
### What changes have you made?

- fixed the Projects page on Safari as the `flex` attribute was causing a stretch on all images 

### Which issue(s) does this PR fix?

Fixes #199 

### Screenshots (if there are design changes)

Before:

<img width="1440" alt="Screenshot 2020-10-26 at 10 36 03" src="https://user-images.githubusercontent.com/53219789/97162038-eaf25400-177e-11eb-9302-16d116967525.png">

After:
<img width="1438" alt="Screenshot 2020-10-26 at 11 32 02" src="https://user-images.githubusercontent.com/53219789/97162050-f2196200-177e-11eb-831b-f4fe1005cf6e.png">

### How to test
- Check the Projects page on Safari and make sure that all the icons retain dimensions on desktop and mobile 
- Nav through the rest of the site on Safari to check for any other display bugs 