### PR TITLE
reverts to two column layout on manifesto page

### DIFF
--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -51,7 +51,7 @@ const Manifesto = () => {
 
   return (
     <Main justifyContent="center">
-      <Container height="75%">
+      <Container height="100%">
       <H1 fontSize={[2, 5]} pb={5}>
           {t("manifesto.header")}
         </H1>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -10,17 +10,25 @@ import {
   FlexboxProps,
   LayoutProps,
   layout,
+  GridProps,
+  grid,
 } from "styled-system";
 
 const Main = styled.main<FlexboxProps>`
   display: flex;
   height: 100%;
+  flex-direction: column;
   ${flexbox};
 `;
 
-const Container = styled.div<LayoutProps & SpaceProps>`
+const Container = styled.div<LayoutProps>`
   ${layout};
-  ${space};
+`;
+
+const Grid = styled.div<GridProps & FlexboxProps>`
+display: grid;
+${grid}; 
+${flexbox}
 `;
 
 const H1 = styled.h1<TypographyProps & SpaceProps>`
@@ -30,9 +38,9 @@ const H1 = styled.h1<TypographyProps & SpaceProps>`
 `;
 
 const Paragraph = styled.p<TypographyProps & SpaceProps>`
-  text-transform: uppercase;
   ${typography};
   ${space};
+  text-transform: uppercase;
   text-align: justify;
   line-height: 1.5;
 `;
@@ -42,18 +50,32 @@ const Manifesto = () => {
   const fontSizes = [3, 4, 5, 5];
 
   return (
-    <Main flexDirection="column" justifyContent="center">
-      <Container minHeight="50%" maxHeight="80%">
-        <H1 fontSize={[4, 5, 6, 6]} pb={5}>
+    <Main justifyContent="center">
+      <Container height="75%">
+      <H1 fontSize={[2, 5]} pb={5}>
           {t("manifesto.header")}
         </H1>
-
-        <Paragraph pb={5} fontSize={fontSizes}>
-          {t("manifesto.manifesto")}
-        </Paragraph>
+        <Grid
+        justifyContent="center" 
+        gridColumnGap="4%" 
+        gridTemplateColumns={[
+          "repeat(1, 100% [col-start])",  
+          "repeat(1, 100% [col-start])",  
+          "repeat(1, 100% [col-start])",  
+          "repeat(2, 48% [col-start])", 
+        ]}
+          >
+        <Paragraph pb={5} fontSize={fontSizes}> 
+            {t("manifesto.manifesto")}  
+          </Paragraph>  
+          <Paragraph pb={5} fontSize={fontSizes}> 
+            {t("manifesto.manifesto")}  
+          </Paragraph>
+        </Grid>
       </Container>
     </Main>
   );
 };
+
 
 export default Manifesto;


### PR DESCRIPTION
### What changes have you made?

- I've changed the manifesto text back to the two-column layout with repeated text (lorem ipsum style)

### Which issue(s) does this PR fix?

Fixes #212 

### Screenshots (if there are design changes)
<img width="1427" alt="Screenshot 2020-11-10 at 16 20 52" src="https://user-images.githubusercontent.com/53219789/98693560-b979ab00-2370-11eb-84a0-936b2b76c5cd.png">


### How to test
go to http://localhost:3000/manifesto and check that the manifesto text displays in two columns on desktop and one column on smaller screen sizes 