### PR TITLE
updates all countdown timers

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -13,7 +13,7 @@ const Main = styled.main<FlexboxProps>`
 const Loading = () => {
   return (
     <Main justifyContent="center">
-      <Timer endDate="2020-11-13" />
+      <Timer endDate="2020-11-27" />
     </Main>
   );
 };

--- a/src/components/project-pages/Belledejour.tsx
+++ b/src/components/project-pages/Belledejour.tsx
@@ -28,7 +28,7 @@ const Belledejour = () => {
         {" "}
         <Img src={knife} alt="knife icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };

--- a/src/components/project-pages/ConsciousShoppingPreview.tsx
+++ b/src/components/project-pages/ConsciousShoppingPreview.tsx
@@ -59,7 +59,7 @@ const ConsciousShoppingPreview = () => {
       <Illustration  src={boots} alt="illustration image"  maxWidth="50%"  gridColumn={1} gridRow={2} justifySelf="flex-end" alignSelf="center"/> 
       <Illustration src={bag} alt="illustration image"  maxWidth="50%" gridColumn={2} justifySelf="center" alignSelf="center"/> 
     <Grid  zIndex={zIndexes.inFront} gridColumn={2} gridRow="2/4" justifySelf="center" alignSelf="center">
-      <Timer endDate="2020-11-20"/> 
+      <Timer endDate="2020-12-21"/> 
       </Grid>
       <Illustration src={concha} alt="illustration image"  maxWidth="50%" gridColumn={2} gridRow={4} justifySelf="flex-start" alignSelf="center"/> 
       <Illustration  src={trex} alt="illustration image" maxWidth="50%" gridColumn={2} gridRow={4} justifySelf="flex-end" alignSelf="center"/>

--- a/src/components/project-pages/EroticStoriesPreview.tsx
+++ b/src/components/project-pages/EroticStoriesPreview.tsx
@@ -27,7 +27,7 @@ const EroticStoriesPreview = () => {
       <Container justifyContent="center" alignItems="center">
         <Img src={statue} alt="statue icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };

--- a/src/components/project-pages/Eye.tsx
+++ b/src/components/project-pages/Eye.tsx
@@ -27,7 +27,7 @@ const Eye = () => {
       <Container justifyContent="center" alignItems="center">
         <Img src={eye} alt="eye icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };

--- a/src/components/project-pages/FashionEditorial.tsx
+++ b/src/components/project-pages/FashionEditorial.tsx
@@ -27,7 +27,7 @@ const FashionEditorial = () => {
       <Container justifyContent="center" alignItems="center">
         <Img src={stairs} alt="stairs icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };

--- a/src/components/project-pages/KaiLandrePreview.tsx
+++ b/src/components/project-pages/KaiLandrePreview.tsx
@@ -20,7 +20,7 @@ const KaiLandrePreview = () => {
     <Fragment>
       <Container flexDirection="column" display="flex" justifyContent="center" alignItems="center">
         <Img src={dragon} alt="dragon icon" maxWidth="30%" />
-        <Timer endDate="2020-11-20" />
+        <Timer endDate="2020-12-21" />
       </Container>
     </Fragment>
   );

--- a/src/components/project-pages/LeoAdef.tsx
+++ b/src/components/project-pages/LeoAdef.tsx
@@ -27,7 +27,7 @@ const LeoAdef = () => {
       <Container justifyContent="center" alignItems="center">
         <Img src={spider} alt="spider icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };

--- a/src/components/project-pages/Map.tsx
+++ b/src/components/project-pages/Map.tsx
@@ -27,7 +27,7 @@ const Map = () => {
       <Container justifyContent="center" alignItems="center">
         <Img src={magnify} alt="magnify icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };

--- a/src/components/project-pages/MarcMedina.tsx
+++ b/src/components/project-pages/MarcMedina.tsx
@@ -27,7 +27,7 @@ const MarcMedina = () => {
       <Container justifyContent="center" alignItems="center">
         <Img src={mask} alt="mask icon" maxWidth="30%" />
       </Container>
-      <Timer endDate="2020-11-20" />
+      <Timer endDate="2020-12-21" />
     </Main>
   );
 };


### PR DESCRIPTION


### What changes have you made?

- updated the loading page countdown timer to 27th November (new launch date)
- updated all other project pages to placeholder date (21st December) 
Note. these will be updated in line with approved launch dates as they come in 

### Which issue(s) does this PR fix?

Fixes #210 

### Screenshots (if there are design changes)
<img width="489" alt="Screenshot 2020-11-10 at 17 13 51" src="https://user-images.githubusercontent.com/53219789/98700110-1fb5fc00-2378-11eb-8c9d-e246d3e0192b.png">

### How to test
go to http://localhost:3000/ and check that the timer is updated to November 27th

check all the other project pages and make sure no timer is close to 0 days 