### PR TITLE
fixes scroll to top button on project page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,19 +47,35 @@ const App = () => {
                 <Route path="/about" exact component={AboutUs} />
                 <Route path="/advertising" exact component={Advertising} />
                 <Route path="/projects" exact component={Projects} />
-                <Route path="/projects/marcmedina" exact component={MarcMedina} />
-                <Route path="/projects/eroticstories" exact component={EroticStories} />
+                <Route
+                  path="/projects/marcmedina"
+                  exact
+                  component={MarcMedina}
+                />
+                <Route
+                  path="/projects/eroticstories"
+                  exact
+                  component={EroticStories}
+                />
                 <Route path="/projects/eyes" exact component={Eye} />
-                <Route path="/projects/belledejour" exact component={Belledejour} />
+                <Route
+                  path="/projects/belledejour"
+                  exact
+                  component={Belledejour}
+                />
                 <Route path="/projects/leoadef" exact component={LeoAdef} />
                 <Route path="/projects/themap" exact component={Map} />
                 <Route path="/projects/kailandre" exact component={KaiLandre} />
-                <Route path="/projects/editorial" exact component={FashionEditorial} />
+                <Route
+                  path="/projects/editorial"
+                  exact
+                  component={FashionEditorial}
+                />
                 <Route
                   path="/projects/consciousshopping"
                   exact
                   component={ConsciousShopping}
-                  />
+                />
               </Switch>
             </Suspense>
           </AppContent>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
 import styled from "styled-components";
 import {
   layout,
@@ -32,6 +32,8 @@ import { Link } from "react-router-dom";
 const Main = styled.main<FlexboxProps & LayoutProps>`
   display: flex;
   height: 100%;
+  overflow: scroll;
+  scroll-behavior: smooth;
   ${flexbox};
   ${layout}
 `;
@@ -76,14 +78,17 @@ const Scrollback = styled.button<ScrollbackProps>`
 `;
 
 const Projects = () => {
+  const ref = useRef<HTMLElement>(null);
   const scrollToTop = useCallback(() => {
-    window.scrollTo(0, 0);
+    if (ref.current) {
+      ref.current.scrollTop = 0;
+    }
   }, []);
 
   const iconSizes = ["100%", "100%", "100%", "100%", "30%"];
 
   return (
-    <Main justifyContent="center" alignItems="center">
+    <Main justifyContent="center" alignItems="center" ref={ref}>
       <Container
         gridTemplateColumns="repeat(3, 1fr)"
         gridTemplateRows="repeat(4, 1fr)"
@@ -99,7 +104,7 @@ const Projects = () => {
           justifySelf="start"
           maxWidth={iconSizes}
         >
-          <Img src={stairs} alt="stairs icon"/>
+          <Img src={stairs} alt="stairs icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/consciousshopping"
@@ -108,7 +113,7 @@ const Projects = () => {
           justifySelf="start"
           maxWidth={iconSizes}
         >
-          <Img src={shell} alt="shell icon"/>
+          <Img src={shell} alt="shell icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/eyes"
@@ -117,7 +122,7 @@ const Projects = () => {
           justifySelf="center"
           maxWidth={iconSizes}
         >
-          <Img src={eye} alt="eye icon"/>
+          <Img src={eye} alt="eye icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/eroticstories"
@@ -126,7 +131,7 @@ const Projects = () => {
           justifySelf="center"
           maxWidth={iconSizes}
         >
-          <Img src={statue} alt="statue icon"/>
+          <Img src={statue} alt="statue icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/kailandre"
@@ -135,7 +140,7 @@ const Projects = () => {
           justifySelf="end"
           maxWidth={iconSizes}
         >
-          <Img src={dragon} alt="dragon icon"/>
+          <Img src={dragon} alt="dragon icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/belledejour"
@@ -144,7 +149,7 @@ const Projects = () => {
           maxWidth={iconSizes}
           justifySelf="start"
         >
-          <Img src={knife} alt="knife icon"/>
+          <Img src={knife} alt="knife icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/marcmedina"
@@ -153,7 +158,7 @@ const Projects = () => {
           justifySelf="center"
           maxWidth={iconSizes}
         >
-          <Img src={mask} alt="mask icon"/>
+          <Img src={mask} alt="mask icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/leoadef"
@@ -162,7 +167,7 @@ const Projects = () => {
           maxWidth={iconSizes}
           justifySelf="center"
         >
-          <Img src={spider} alt="spider icon"/>
+          <Img src={spider} alt="spider icon" />
         </ProjectLink>
         <ProjectLink
           to="/projects/themap"
@@ -171,7 +176,7 @@ const Projects = () => {
           justifySelf="end"
           maxWidth={iconSizes}
         >
-          <Img src={magnify} alt="magnify icon"/>
+          <Img src={magnify} alt="magnify icon" />
         </ProjectLink>
       </Container>
       <BuyButtonContainer


### PR DESCRIPTION
### What changes have you made?
NB. the only changes are on lines 35, 36, 81 - 85 and 91 everything else is linting

- adds scroll to the projects page itself
- adjusts scroll to top function to use `refs` from react rather than the global `window` (vanilla js)

### Which issue(s) does this PR fix?

Fixes #203

### Screenshots (if there are design changes)

### How to test

- scroll to bottom of projects page
- click up button, should smooth scroll to top
