### PR TITLE
adds missing icon to image carousel

### DIFF
--- a/src/components/project-pages/ConsciousShopping.tsx
+++ b/src/components/project-pages/ConsciousShopping.tsx
@@ -22,6 +22,8 @@ import sunglassesImg from "../assets/conscious-shopping/sunglasses.jpg";
 import nadiaImg from "../assets/conscious-shopping/nadia.jpg";
 import conchaImg from "../assets/conscious-shopping/concha.jpg";
 import laiaImg from "../assets/conscious-shopping/laia.jpg";
+import bagImg from "../assets/conscious-shopping/bag.jpg";
+
 // import ConsciousShoppingPreview from "./ConsciousShoppingPreview";
 
 const Main = styled.main<FlexboxProps & TypographyProps>`
@@ -120,7 +122,7 @@ const ConsciousShopping = () => {
     },
     {
       bigImage: nadiaImg,
-      smallImage: conchaImg,
+      smallImage: bagImg,
       interviewText: t("conscious-shopping.nadia"),
       alt:"Nadia image"
     },


### PR DESCRIPTION
### What changes have you made?

- added the handbag image to the image carousel 

### Which issue(s) does this PR fix?

Fixes #215 

### Screenshots (if there are design changes)

<img width="611" alt="Screenshot 2020-11-12 at 12 17 21" src="https://user-images.githubusercontent.com/53219789/98933519-0a101600-24e1-11eb-89de-e3c38eab867f.png">


### How to test
go to http://localhost:3000/projects/consciousshopping and check that the handbag icon displays when clicking through the image carousel