### PR TITLE
reduces padding on nav menu logo

### DIFF
--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -37,7 +37,7 @@ const overlayStyles = css`
 
 const Overlay = styled.dialog<{ isOpen: boolean }>`
   display: none;
-  ${(props) => props.isOpen && overlayStyles}
+  ${props => props.isOpen && overlayStyles}
 `;
 
 const MenuButton = styled.button<TypographyProps & PositionProps>`
@@ -129,7 +129,7 @@ const NavMenu = () => {
           to="/oxymore"
           fontSize={fontSizes}
           position="absolute"
-          left={30}
+          left={24}
           top={24}
           onClick={() => setIsOpen(!isOpen)}
         >


### PR DESCRIPTION
### What changes have you made?
- reduced the padding of the oxymore logo on the nav menu-overlay to match all other instances of the oxymore logo

### Which issue(s) does this PR fix?

Fixes #230 

### Screenshots (if there are design changes)
<img width="679" alt="Screenshot 2020-11-16 at 15 24 54" src="https://user-images.githubusercontent.com/53219789/99263733-e5d57180-281f-11eb-8701-c04a8714d887.png">


### How to test
check that there is no jump between logos when toggling the nav menu 