### PR TITLE
fixes padding on advertising page

### DIFF
--- a/src/components/Advertising.tsx
+++ b/src/components/Advertising.tsx
@@ -35,16 +35,17 @@ const Advertising: React.FC = () => {
     <Flex
       flex="auto"
       flexDirection={["column", "column", "column", "row", "row"]}
+      justifyContent="center"
     >
       <Flex
         flex="auto"
         flexDirection="column"
-        p={4}
         mb={4}
         minWidth={columnWidths}
         width={columnWidths}
+        mr={[0, 0, 0, 2]}
       >
-        <Img src={salazraki} alt="Salazraki image" mb={4}></Img>
+        <Img src={salazraki} alt="Salazraki image" mb={2}></Img>
         <P fontSize={fontSizes} textAlign="justify">
           {t("advertising.salazraki")}
         </P>
@@ -52,12 +53,13 @@ const Advertising: React.FC = () => {
       <Flex
         flex="auto"
         flexDirection="column"
-        p={4}
+        p={0}
         mb={4}
         minWidth={columnWidths}
         width={columnWidths}
+        ml={[0, 0, 0, 2]}
       >
-        <Img src={voltrova} alt="Voltrova image" mb={4}></Img>
+        <Img src={voltrova} alt="Voltrova image" mb={2}></Img>
         <P fontSize={fontSizes} textAlign="justify">
           {t("advertising.voltrova")}
         </P>

--- a/src/components/Advertising.tsx
+++ b/src/components/Advertising.tsx
@@ -34,7 +34,7 @@ const Advertising: React.FC = () => {
   return (
     <Flex
       flex="auto"
-      flexDirection={["column", "column", "column", "row", "row"]}
+      flexDirection={["column", "column", "column", "row"]}
       justifyContent="center"
     >
       <Flex


### PR DESCRIPTION
### What changes have you made?
- the padding on the advertising page was a bit intense on mobile so I've reduced it and also added a `justify-content: center` on the outer `Flex` to get the two sides to balance out

### Which issue(s) does this PR fix?

Fixes #249 

### Screenshots (if there are design changes)
<img width="232" alt="Screenshot 2020-11-24 at 15 44 47" src="https://user-images.githubusercontent.com/53219789/100109361-0c248e00-2e6c-11eb-9fcd-b147eafc6c9e.png">


### How to test
check http://localhost:3000/advertising and make sure the padding looks natural on mobile