### PR TITLE
adjusts text align on contact page

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -11,12 +11,12 @@ const Container = styled.div<ContactPageProps>`
   text-transform: uppercase;
 `;
 
-const H2 = styled.h2<ContactPageProps>`
+const H1 = styled.h1<ContactPageProps>`
   ${space};
   ${typography};
 `;
 
-const H3 = styled.h3<ContactPageProps>`
+const H2 = styled.h2<ContactPageProps>`
   ${space};
   ${typography};
 `;
@@ -32,12 +32,12 @@ const Contact = () => {
   return (
     <Flex flex="auto" alignItems="center">
       <Container textAlign="justify">
-        <H2 fontSize={[4, 5, 6, 7]} py={3}>
+        <H1 fontSize={[4, 5, 6, 7]} py={3}>
           {t("contact.header")}
-        </H2>
-        <H3 fontSize={fontSizes} py={3}>
+        </H1>
+        <H2 fontSize={fontSizes} py={3}>
           {t("contact.subheader")}
-        </H3>
+        </H2>
         <ContactInfo fontSize={fontSizes} py={1}>
           <a
             href="mailto:ox@oxymore.com"

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,33 +1,27 @@
 import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import {
-  space,
-  typography,
-  layout,
-  SpaceProps,
-  TypographyProps,
-  LayoutProps,
-} from "styled-system";
+import { space, typography, SpaceProps, TypographyProps } from "styled-system";
 import Flex from "./Flex";
 
-const Container = styled.div<TypographyProps & LayoutProps>`
+type ContactPageProps = SpaceProps & TypographyProps;
+
+const Container = styled.div<ContactPageProps>`
   ${typography};
-  ${layout};
   text-transform: uppercase;
 `;
 
-const H1 = styled.h1<SpaceProps & TypographyProps>`
+const H2 = styled.h2<ContactPageProps>`
   ${space};
   ${typography};
 `;
 
-const H2 = styled.h2<SpaceProps & TypographyProps>`
+const H3 = styled.h3<ContactPageProps>`
   ${space};
   ${typography};
 `;
 
-const ContactInfo = styled.p<SpaceProps & TypographyProps>`
+const ContactInfo = styled.p<ContactPageProps>`
   ${space};
   ${typography};
 `;
@@ -37,30 +31,23 @@ const Contact = () => {
   const fontSizes = [2, 3, 4, 5];
   return (
     <Flex flex="auto" alignItems="center">
-      <Container
-        textAlign={["center", "center", "center", "justify"]}
-        height="50%"
-      >
-        <ul>
-          <H1 fontSize={[4, 5, 6, 7]} py={3}>
-            {t("contact.header")}
-          </H1>
-          <H2 fontSize={fontSizes} py={3}>
-            {t("contact.subheader")}
-          </H2>
-          <ContactInfo fontSize={fontSizes} py={1}>
-            <a
-              href="mailto:ox@oxymore.com"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {t("contact.email")}
-            </a>
-          </ContactInfo>
-          <ContactInfo fontSize={fontSizes}>
-            {t("contact.location")}
-          </ContactInfo>
-        </ul>
+      <Container textAlign="justify">
+        <H2 fontSize={[4, 5, 6, 7]} py={3}>
+          {t("contact.header")}
+        </H2>
+        <H3 fontSize={fontSizes} py={3}>
+          {t("contact.subheader")}
+        </H3>
+        <ContactInfo fontSize={fontSizes} py={1}>
+          <a
+            href="mailto:ox@oxymore.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t("contact.email")}
+          </a>
+        </ContactInfo>
+        <ContactInfo fontSize={fontSizes}>{t("contact.location")}</ContactInfo>
       </Container>
     </Flex>
   );


### PR DESCRIPTION
### What changes have you made?
- changed the text-align on the contact page to justify across all screen sizes in line with the look and feel of the rest of the site  
- refactored the code a bit removing any unnecessary props 

### Which issue(s) does this PR fix?

Fixes #251 

### Screenshots (if there are design changes)

<img width="316" alt="Screenshot 2020-11-24 at 16 13 56" src="https://user-images.githubusercontent.com/53219789/100113934-290f9000-2e71-11eb-98cc-6cabe118778c.png">


### How to test
go to http://localhost:3000/contact and make sure display looks good on desktop and mobile