### PR TITLE
adds extra breakpoint to create more space for manifesto paragraphs

### DIFF
--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -5,13 +5,15 @@ import { space, typography, SpaceProps, TypographyProps } from "styled-system";
 import Grid from "./Grid";
 import Flex from "./Flex";
 
-const H1 = styled.h1<TypographyProps & SpaceProps>`
+type ManifestoProps = TypographyProps & SpaceProps;
+
+const H1 = styled.h1<ManifestoProps>`
   text-transform: uppercase;
   ${typography};
   ${space};
 `;
 
-const Paragraph = styled.p<TypographyProps & SpaceProps>`
+const Paragraph = styled.p<ManifestoProps>`
   ${typography};
   ${space};
   text-transform: uppercase;
@@ -31,6 +33,7 @@ const Manifesto = () => {
       <Grid
         gridColumnGap="4%"
         gridTemplateColumns={[
+          "repeat(1, 100% [col-start])",
           "repeat(1, 100% [col-start])",
           "repeat(1, 100% [col-start])",
           "repeat(1, 100% [col-start])",


### PR DESCRIPTION
### What changes have you made?
- very minor cosmetic change to make the text look a bit less squished on smaller desktop sizes
- I've just added an extra breakpoint in the grid to let the text flow out into one column rather than two

### Which issue(s) does this PR fix?

Fixes #253 

### Screenshots (if there are design changes)
before: 
<img width="772" alt="Screenshot 2020-11-24 at 16 37 32" src="https://user-images.githubusercontent.com/53219789/100117079-bdc7bd00-2e74-11eb-93b7-571a020ebe28.png">

after:
<img width="755" alt="Screenshot 2020-11-24 at 16 38 10" src="https://user-images.githubusercontent.com/53219789/100117185-d3d57d80-2e74-11eb-9fd2-76ddfa7475d3.png">


### How to test
http://localhost:3000/manifesto