### PR TITLE
So/add links project pages

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -43,7 +43,7 @@ const ProjectsLink = styled(NavLink)<TypographyProps & FlexboxProps>`
   align-self: center;
   align-items: flex-start;
   justify-content: flex-start;
-  transition: transform 0.2s;
+  transition: transform 0.5s;
   &:hover {
     transform: scale(1.01);
   ${flexbox}

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -11,7 +11,6 @@ import {
   TypographyProps,
   typography,
 } from "styled-system";
-
 import BuyButton from "./BuyButton";
 import NavMenu from "./NavMenu";
 import oxymore from "./assets/home-page/oxymore.png";

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -30,23 +30,25 @@ import BuyButton from "./BuyButton";
 import { zIndexes } from "./theme";
 import Flex from "./Flex";
 
-const Container = styled.div<LayoutProps & FlexboxProps & GridProps>`
+type ProjectPageProps = LayoutProps & FlexboxProps & GridProps;
+
+const Container = styled.div<ProjectPageProps>`
   ${layout};
   ${flexbox};
   ${grid};
 `;
 
-const BuyButtonContainer = styled.div<PositionProps & SpaceProps>`
-  ${position};
-  ${space};
-`;
-
-const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
+const ProjectLinkWrapper = styled.div<ProjectPageProps>`
   ${layout};
   ${grid};
   ${flexbox};
   display: flex;
   align-items: center;
+`;
+
+const BuyButtonContainer = styled.div<PositionProps & SpaceProps>`
+  ${position};
+  ${space};
 `;
 
 const Img = styled.img<LayoutProps>`

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -17,7 +17,6 @@ import {
   background,
 } from "styled-system";
 import { Link } from "react-router-dom";
-
 import stairs from "./assets/project-page/stairs.png";
 import shell from "./assets/project-page/shell.png";
 import eye from "./assets/project-page/eye.png";
@@ -52,7 +51,7 @@ const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
 
 const Img = styled.img<LayoutProps>`
   ${layout};
-  transition: transform 0.2s;
+  transition: transform 0.5s;
   &:hover {
     transform: scale(1.05);
 `;

--- a/src/components/project-pages/Belledejour.tsx
+++ b/src/components/project-pages/Belledejour.tsx
@@ -5,6 +5,7 @@ import { LayoutProps, layout } from "styled-system";
 import knife from "../assets/project-page/knife.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -12,12 +13,20 @@ const Img = styled.img<LayoutProps>`
 
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={knife} alt="knife icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={knife} alt="knife icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/Belledejour.tsx
+++ b/src/components/project-pages/Belledejour.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
 import { LayoutProps, layout } from "styled-system";

--- a/src/components/project-pages/ConsciousShoppingPreview.tsx
+++ b/src/components/project-pages/ConsciousShoppingPreview.tsx
@@ -18,6 +18,7 @@ import shell from "../assets/conscious-shopping/concha.jpg";
 import Timer from "../Timer";
 import { zIndexes } from "../theme";
 import { Link } from "react-router-dom";
+import Flex from "../Flex";
 
 type GridLayoutProps = FlexboxProps & LayoutProps & PositionProps & GridProps;
 
@@ -43,6 +44,14 @@ const Illustration = styled.img<GridLayoutProps>`
   opacity: 0.5;
 `;
 
+const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
+  ${layout};
+  ${grid};
+  ${flexbox};
+  display: flex;
+  align-items: center;
+`;
+
 const ConsciousShoppingPreview: React.FC<{ launchDate: string }> = ({
   launchDate,
 }) => {
@@ -54,15 +63,17 @@ const ConsciousShoppingPreview: React.FC<{ launchDate: string }> = ({
       gridTemplateRows="repeat(5, 20%)"
       alignItems="center"
     >
-      <Link to="/projects">
-        <ProjectIcon
-          src={projectIcon}
-          alt="icon image"
-          maxWidth="20%"
-          gridColumn={1}
-          gridRow={1}
-        />
-      </Link>
+      <ProjectLinkWrapper>
+        <Link to="/projects">
+          <ProjectIcon
+            src={projectIcon}
+            alt="icon image"
+            maxWidth="20%"
+            gridColumn={1}
+            gridRow={1}
+          />
+        </Link>
+      </ProjectLinkWrapper>
       <Illustration
         src={boots}
         alt="illustration image"

--- a/src/components/project-pages/ConsciousShoppingPreview.tsx
+++ b/src/components/project-pages/ConsciousShoppingPreview.tsx
@@ -63,17 +63,15 @@ const ConsciousShoppingPreview: React.FC<{ launchDate: string }> = ({
       gridTemplateRows="repeat(5, 20%)"
       alignItems="center"
     >
-      <ProjectLinkWrapper>
-        <Link to="/projects">
-          <ProjectIcon
-            src={projectIcon}
-            alt="icon image"
-            maxWidth="20%"
-            gridColumn={1}
-            gridRow={1}
-          />
-        </Link>
-      </ProjectLinkWrapper>
+      <Link to="/projects">
+        <ProjectIcon
+          src={projectIcon}
+          alt="icon image"
+          maxWidth="20%"
+          gridColumn={1}
+          gridRow={1}
+        />
+      </Link>
       <Illustration
         src={boots}
         alt="illustration image"

--- a/src/components/project-pages/ConsciousShoppingPreview.tsx
+++ b/src/components/project-pages/ConsciousShoppingPreview.tsx
@@ -18,7 +18,6 @@ import shell from "../assets/conscious-shopping/concha.jpg";
 import Timer from "../Timer";
 import { zIndexes } from "../theme";
 import { Link } from "react-router-dom";
-import Flex from "../Flex";
 
 type GridLayoutProps = FlexboxProps & LayoutProps & PositionProps & GridProps;
 

--- a/src/components/project-pages/ConsciousShoppingPreview.tsx
+++ b/src/components/project-pages/ConsciousShoppingPreview.tsx
@@ -44,14 +44,6 @@ const Illustration = styled.img<GridLayoutProps>`
   opacity: 0.5;
 `;
 
-const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
-  ${layout};
-  ${grid};
-  ${flexbox};
-  display: flex;
-  align-items: center;
-`;
-
 const ConsciousShoppingPreview: React.FC<{ launchDate: string }> = ({
   launchDate,
 }) => {

--- a/src/components/project-pages/EroticStoriesPreview.tsx
+++ b/src/components/project-pages/EroticStoriesPreview.tsx
@@ -4,6 +4,7 @@ import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import statue from "../assets/project-page/statue.png";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -20,9 +21,11 @@ const EroticStoriesPreview: React.FC<{ launchDate: string }> = ({
       justifyContent="center"
       alignItems="center"
     >
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={statue} alt="statue icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={statue} alt="statue icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Flex>
   );

--- a/src/components/project-pages/Eye.tsx
+++ b/src/components/project-pages/Eye.tsx
@@ -5,18 +5,27 @@ import { layout, LayoutProps } from "styled-system";
 import eye from "../assets/project-page/eye.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
 `;
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={eye} alt="eye icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={eye} alt="eye icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 const launchDate = "2020-12-21";

--- a/src/components/project-pages/Eye.tsx
+++ b/src/components/project-pages/Eye.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";

--- a/src/components/project-pages/FashionEditorialPreview.tsx
+++ b/src/components/project-pages/FashionEditorialPreview.tsx
@@ -4,6 +4,7 @@ import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import stairs from "../assets/project-page/stairs.png";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -11,12 +12,20 @@ const Img = styled.img<LayoutProps>`
 
 const FashionEditorial: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={stairs} alt="stairs icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={stairs} alt="stairs icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/FashionEditorialPreview.tsx
+++ b/src/components/project-pages/FashionEditorialPreview.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";

--- a/src/components/project-pages/KaiLandrePreview.tsx
+++ b/src/components/project-pages/KaiLandrePreview.tsx
@@ -1,13 +1,10 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import { layout, LayoutProps } from "styled-system";
 import dragon from "../assets/project-page/dragon.png";
-
-const Container = styled.div<FlexboxProps & LayoutProps>`
-  ${flexbox};
-  ${layout};
-`;
+import { Link } from "react-router-dom";
+import Flex from "../Flex";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -18,17 +15,20 @@ interface KaiLandrePreviewProps {
 }
 const KaiLandrePreview: React.FC<KaiLandrePreviewProps> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Container
-        flexDirection="column"
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-      >
-        <Img src={dragon} alt="dragon icon" maxWidth="30%" />
-        <Timer launchDate={launchDate} />
-      </Container>
-    </Fragment>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={dragon} alt="dragon icon" maxWidth="30%" />
+        </Flex>
+      </Link>
+      <Timer launchDate={launchDate} />
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/LeoAdef.tsx
+++ b/src/components/project-pages/LeoAdef.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment } from "react";
 import styled from "styled-components";
-
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import spider from "../assets/project-page/spider.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -13,12 +13,20 @@ const Img = styled.img<LayoutProps>`
 
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={spider} alt="spider icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={spider} alt="spider icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/LeoAdef.tsx
+++ b/src/components/project-pages/LeoAdef.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";

--- a/src/components/project-pages/Map.tsx
+++ b/src/components/project-pages/Map.tsx
@@ -1,10 +1,11 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import magnify from "../assets/project-page/magnify.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -12,12 +13,20 @@ const Img = styled.img<LayoutProps>`
 
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={magnify} alt="magnify icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={magnify} alt="magnify icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/MarcMedina.tsx
+++ b/src/components/project-pages/MarcMedina.tsx
@@ -5,6 +5,7 @@ import Timer from "../Timer";
 import mask from "../assets/project-page/mask.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -12,12 +13,20 @@ const Img = styled.img<LayoutProps>`
 
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={mask} alt="mask icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={mask} alt="mask icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/MarcMedina.tsx
+++ b/src/components/project-pages/MarcMedina.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import { layout, LayoutProps } from "styled-system";
 import Timer from "../Timer";


### PR DESCRIPTION
### What changes have you made?
- I've added a `Link` to all of the project preview icons to allow the user to go back to the projects page without having to go via the homepage
- I've unified the code across all preview pages to use the following snippet: 

`<Flex
      flex="auto"
      overflow="hidden"
      flexDirection="column"
      justifyContent="center"
      alignItems="center"
    >
      <Link to="/projects">
        <Flex justifyContent="center" alignItems="center">
          <Img src={someIcon} alt="some icon" maxWidth="30%" />
        </Flex>
      </Link>
      <Timer launchDate={launchDate} />
    </Flex>`

Eventually I'll abstract this into one component and pass each of the project pages image and launch date props since they are the only things that change.

### Which issue(s) does this PR fix?

Fixes #

### Screenshots (if there are design changes)

No design changes 

### How to test
Move through each of the project pages and check that you can click on the icon of its preview page to get back to the projects page 