### PR TITLE
adds links to project preview pages

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -43,7 +43,7 @@ const ProjectsLink = styled(NavLink)<TypographyProps & FlexboxProps>`
   align-self: center;
   align-items: flex-start;
   justify-content: flex-start;
-  transition: transform 0.2s;
+  transition: transform 0.5s;
   &:hover {
     transform: scale(1.01);
   ${flexbox}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -52,7 +52,7 @@ const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
 
 const Img = styled.img<LayoutProps>`
   ${layout};
-  transition: transform 0.2s;
+  transition: transform 0.5s;
   &:hover {
     transform: scale(1.05);
 `;

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,12 +3,8 @@ import styled from "styled-components";
 import {
   layout,
   space,
-  flexbox,
-  grid,
   LayoutProps,
   SpaceProps,
-  FlexboxProps,
-  GridProps,
   position,
   PositionProps,
   typography,
@@ -16,45 +12,14 @@ import {
   BackgroundProps,
   background,
 } from "styled-system";
-import { Link } from "react-router-dom";
-
-import stairs from "./assets/project-page/stairs.png";
-import shell from "./assets/project-page/shell.png";
-import eye from "./assets/project-page/eye.png";
-import statue from "./assets/project-page/statue.png";
-import dragon from "./assets/project-page/dragon.png";
-import knife from "./assets/project-page/knife.png";
-import mask from "./assets/project-page/mask.png";
-import spider from "./assets/project-page/spider.png";
-import magnify from "./assets/project-page/magnify.png";
 import BuyButton from "./BuyButton";
 import { zIndexes } from "./theme";
 import Flex from "./Flex";
-
-const Container = styled.div<LayoutProps & FlexboxProps & GridProps>`
-  ${layout};
-  ${flexbox};
-  ${grid};
-`;
+import ProjectsGrid from "./ProjectsGrid";
 
 const BuyButtonContainer = styled.div<PositionProps & SpaceProps>`
   ${position};
   ${space};
-`;
-
-const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
-  ${layout};
-  ${grid};
-  ${flexbox};
-  display: flex;
-  align-items: center;
-`;
-
-const Img = styled.img<LayoutProps>`
-  ${layout};
-  transition: transform 0.5s;
-  &:hover {
-    transform: scale(1.05);
 `;
 
 type ScrollbackProps = PositionProps &
@@ -77,111 +42,14 @@ const Projects = () => {
     }
   }, []);
 
-  const iconSizes = ["100%", "100%", "100%", "100%", "30%"];
+  const iconSizes = ["100%", "100%", "75%", "30%"];
 
   return (
     <Flex flex="auto" justifyContent="center" alignItems="center">
-      <Container
-        gridTemplateColumns="repeat(3, 1fr)"
-        gridTemplateRows="repeat(4, 1fr)"
-        display="grid"
-        justifyItems="center"
-        alignItems="center"
-      >
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 3]}
-          gridRow={[1, 1, 1, 1, 1]}
-          justifySelf="start"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/editorial">
-            <Img src={stairs} alt="stairs icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 2]}
-          gridRow={[2, 2, 2, 2, "1/3"]}
-          justifySelf="start"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/consciousshopping">
-            <Img src={shell} alt="shell icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 1]}
-          gridRow={[3, 3, 3, 3, "1/3"]}
-          justifySelf="center"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/eyes">
-            <Img src={eye} alt="eye icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 1]}
-          gridRow={[4, 4, 4, 4, 3]}
-          justifySelf="center"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/eroticstories">
-            <Img src={statue} alt="statue icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 1]}
-          gridRow={[5, 5, 5, 5, "2/4"]}
-          justifySelf="end"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/kailandre">
-            <Img src={dragon} alt="dragon icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 3]}
-          gridRow={[6, 6, 6, 6, 3]}
-          maxWidth={iconSizes}
-          justifySelf="start"
-        >
-          <Link to="/projects/belledejour">
-            <Img src={knife} alt="knife icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 3]}
-          gridRow={[7, 7, 7, 7, 2]}
-          justifySelf="center"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/marcmedina">
-            <Img src={mask} alt="mask icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 2]}
-          gridRow={[8, 8, 8, 8, "2/4"]}
-          maxWidth={iconSizes}
-          justifySelf="center"
-        >
-          <Link to="/projects/leoadef">
-            <Img src={spider} alt="spider icon" />
-          </Link>
-        </ProjectLinkWrapper>
-        <ProjectLinkWrapper
-          gridColumn={[2, 2, 2, 2, 2]}
-          gridRow={[9, 9, 9, 9, 2]}
-          justifySelf="end"
-          maxWidth={iconSizes}
-        >
-          <Link to="/projects/themap">
-            <Img src={magnify} alt="magnify icon" />
-          </Link>
-        </ProjectLinkWrapper>
-      </Container>
+      <ProjectsGrid />
       <BuyButtonContainer
         position="fixed"
-        bottom={["40%", "40%", "40%", "40%", "15%"]}
+        bottom={["40%", "40%", "40%", "15%"]}
         zIndex={zIndexes.inFront}
       >
         <BuyButton
@@ -191,7 +59,7 @@ const Projects = () => {
       </BuyButtonContainer>
 
       <Scrollback
-        display={["block", "block", "block", "block", "none"]}
+        display={["block", "block", "block", "none"]}
         position="fixed"
         bottom={6}
         left={6}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -42,8 +42,6 @@ const Projects = () => {
     }
   }, []);
 
-  const iconSizes = ["100%", "100%", "75%", "30%"];
-
   return (
     <Flex flex="auto" justifyContent="center" alignItems="center">
       <ProjectsGrid />

--- a/src/components/ProjectsGrid.tsx
+++ b/src/components/ProjectsGrid.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  layout,
+  flexbox,
+  grid,
+  LayoutProps,
+  FlexboxProps,
+  GridProps,
+} from "styled-system";
+import { Link } from "react-router-dom";
+import stairs from "./assets/project-page/stairs.png";
+import shell from "./assets/project-page/shell.png";
+import eye from "./assets/project-page/eye.png";
+import statue from "./assets/project-page/statue.png";
+import dragon from "./assets/project-page/dragon.png";
+import knife from "./assets/project-page/knife.png";
+import mask from "./assets/project-page/mask.png";
+import spider from "./assets/project-page/spider.png";
+import magnify from "./assets/project-page/magnify.png";
+import Grid from "./Grid";
+
+const ProjectLinkWrapper = styled.div<LayoutProps & GridProps & FlexboxProps>`
+  ${layout};
+  ${grid};
+  ${flexbox};
+  display: flex;
+  align-items: center;
+`;
+
+const Img = styled.img<LayoutProps>`
+  ${layout};
+  transition: transform 0.5s;
+  &:hover {
+    transform: scale(1.05);
+`;
+
+const ProjectsGrid = () => {
+  const iconSizes = ["100%", "100%", "60%", "30%"];
+
+  return (
+    <Grid
+      gridTemplateColumns="repeat(3, 1fr)"
+      gridTemplateRows="repeat(4, 1fr)"
+    >
+      <ProjectLinkWrapper
+        gridColumn={[2, 2, 2, 2]}
+        gridRow={1}
+        justifySelf={["center", "center", "center", "end"]}
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/editorial">
+          <Img src={stairs} alt="stairs icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={2}
+        gridRow={[2, 2, 2, "1/3"]}
+        justifySelf={["center", "center", "center", "start"]}
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/consciousshopping">
+          <Img src={shell} alt="shell icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={[2, 2, 2, 1]}
+        gridRow={[3, 3, 3, "1/3"]}
+        justifySelf="center"
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/eyes">
+          <Img src={eye} alt="eye icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={[2, 2, 2, 1]}
+        gridRow={[4, 4, 4, 3]}
+        justifySelf="center"
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/eroticstories">
+          <Img src={statue} alt="statue icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={[2, 2, 2, 1]}
+        gridRow={[5, 5, 5, "2/4"]}
+        justifySelf={["center", "center", "center", "end"]}
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/kailandre">
+          <Img src={dragon} alt="dragon icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={[2, 2, 2, 3]}
+        gridRow={[6, 6, 6, 3]}
+        maxWidth={iconSizes}
+        justifySelf={["center", "center", "center", "start"]}
+      >
+        <Link to="/projects/belledejour">
+          <Img src={knife} alt="knife icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={[2, 2, 2, 3]}
+        gridRow={[7, 7, 7, 2]}
+        justifySelf="center"
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/marcmedina">
+          <Img src={mask} alt="mask icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={2}
+        gridRow={[8, 8, 8, "2/4"]}
+        maxWidth={iconSizes}
+        justifySelf="center"
+      >
+        <Link to="/projects/leoadef">
+          <Img src={spider} alt="spider icon" />
+        </Link>
+      </ProjectLinkWrapper>
+      <ProjectLinkWrapper
+        gridColumn={2}
+        gridRow={[9, 9, 9, 2]}
+        justifySelf={["center", "center", "center", "end"]}
+        maxWidth={iconSizes}
+      >
+        <Link to="/projects/themap">
+          <Img src={magnify} alt="magnify icon" />
+        </Link>
+      </ProjectLinkWrapper>
+    </Grid>
+  );
+};
+
+export default ProjectsGrid;

--- a/src/components/project-pages/Belledejour.tsx
+++ b/src/components/project-pages/Belledejour.tsx
@@ -5,6 +5,7 @@ import { LayoutProps, layout } from "styled-system";
 import knife from "../assets/project-page/knife.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -13,9 +14,11 @@ const Img = styled.img<LayoutProps>`
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
     <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={knife} alt="knife icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={knife} alt="knife icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Fragment>
   );

--- a/src/components/project-pages/EroticStoriesPreview.tsx
+++ b/src/components/project-pages/EroticStoriesPreview.tsx
@@ -4,6 +4,7 @@ import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import statue from "../assets/project-page/statue.png";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -20,9 +21,11 @@ const EroticStoriesPreview: React.FC<{ launchDate: string }> = ({
       justifyContent="center"
       alignItems="center"
     >
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={statue} alt="statue icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={statue} alt="statue icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Flex>
   );

--- a/src/components/project-pages/Eye.tsx
+++ b/src/components/project-pages/Eye.tsx
@@ -5,6 +5,7 @@ import { layout, LayoutProps } from "styled-system";
 import eye from "../assets/project-page/eye.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -12,9 +13,11 @@ const Img = styled.img<LayoutProps>`
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
     <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={eye} alt="eye icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={eye} alt="eye icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Fragment>
   );

--- a/src/components/project-pages/FashionEditorialPreview.tsx
+++ b/src/components/project-pages/FashionEditorialPreview.tsx
@@ -1,9 +1,10 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import stairs from "../assets/project-page/stairs.png";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -11,12 +12,20 @@ const Img = styled.img<LayoutProps>`
 
 const FashionEditorial: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={stairs} alt="stairs icon" maxWidth="30%" />
-      </Flex>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={stairs} alt="stairs icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
-    </Fragment>
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/KaiLandrePreview.tsx
+++ b/src/components/project-pages/KaiLandrePreview.tsx
@@ -1,13 +1,10 @@
-import React, { Fragment } from "react";
+import React from "react";
 import styled from "styled-components";
 import Timer from "../Timer";
-import { FlexboxProps, flexbox, layout, LayoutProps } from "styled-system";
+import { layout, LayoutProps } from "styled-system";
 import dragon from "../assets/project-page/dragon.png";
-
-const Container = styled.div<FlexboxProps & LayoutProps>`
-  ${flexbox};
-  ${layout};
-`;
+import { Link } from "react-router-dom";
+import Flex from "../Flex";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -18,17 +15,20 @@ interface KaiLandrePreviewProps {
 }
 const KaiLandrePreview: React.FC<KaiLandrePreviewProps> = ({ launchDate }) => {
   return (
-    <Fragment>
-      <Container
-        flexDirection="column"
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-      >
-        <Img src={dragon} alt="dragon icon" maxWidth="30%" />
-        <Timer launchDate={launchDate} />
-      </Container>
-    </Fragment>
+    <Flex
+      flex="auto"
+      overflow="hidden"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={dragon} alt="dragon icon" maxWidth="30%" />
+        </Flex>
+      </Link>
+      <Timer launchDate={launchDate} />
+    </Flex>
   );
 };
 

--- a/src/components/project-pages/LeoAdef.tsx
+++ b/src/components/project-pages/LeoAdef.tsx
@@ -1,11 +1,11 @@
 import React, { Fragment } from "react";
 import styled from "styled-components";
-
 import Timer from "../Timer";
 import { layout, LayoutProps } from "styled-system";
 import spider from "../assets/project-page/spider.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -14,9 +14,11 @@ const Img = styled.img<LayoutProps>`
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
     <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={spider} alt="spider icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={spider} alt="spider icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Fragment>
   );

--- a/src/components/project-pages/Map.tsx
+++ b/src/components/project-pages/Map.tsx
@@ -5,6 +5,7 @@ import { layout, LayoutProps } from "styled-system";
 import magnify from "../assets/project-page/magnify.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -13,9 +14,11 @@ const Img = styled.img<LayoutProps>`
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
     <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={magnify} alt="magnify icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={magnify} alt="magnify icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Fragment>
   );

--- a/src/components/project-pages/MarcMedina.tsx
+++ b/src/components/project-pages/MarcMedina.tsx
@@ -5,6 +5,7 @@ import Timer from "../Timer";
 import mask from "../assets/project-page/mask.png";
 import PreviewOrProjectPage from "./PreviewOrProjectPage";
 import Flex from "../Flex";
+import { Link } from "react-router-dom";
 
 const Img = styled.img<LayoutProps>`
   ${layout};
@@ -13,9 +14,11 @@ const Img = styled.img<LayoutProps>`
 const PreviewPage: React.FC<{ launchDate: string }> = ({ launchDate }) => {
   return (
     <Fragment>
-      <Flex justifyContent="center" alignItems="center">
-        <Img src={mask} alt="mask icon" maxWidth="30%" />
-      </Flex>
+      <Link to="/projects">
+        <Flex justifyContent="center" alignItems="center">
+          <Img src={mask} alt="mask icon" maxWidth="30%" />
+        </Flex>
+      </Link>
       <Timer launchDate={launchDate} />
     </Fragment>
   );


### PR DESCRIPTION
### What changes have you made?
- I've added a `Link` on the project preview pages so the user can go back to the projects page without having to go via the homepage 
- the `Projects` component had so much code so I've moved the contents of the grid into its own file named `ProjectsGrid` which should be a bit more manageable to work with 

### Which issue(s) does this PR fix?

Fixes #240 

### Screenshots (if there are design changes)
No design changes

### How to test
Move through the project pages and check that you can click back to the projects page on each of the preview icons
