### PR TITLE
replaces placeholder text contact page 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -14,9 +14,7 @@
   },
   "contact": {
     "header": "Contact",
-    "subheader": "Oxymore is a biannual publication bla bla bla bla",
-    "email": "ox@oxymore.com",
-    "location": "Barcelona"
+    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM BASED IN GÓTICO, BARCELONA"
   },
   "manifesto": {
     "header": "Manifesto",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -14,9 +14,7 @@
   },
   "contact": {
     "header": "Contácto",
-    "subheader": "Oxymore es una publicación bianual bla bla bla bla",
-    "email": "ox@oxymore.com",
-    "location": "Barcelona"
+    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM BASED IN GÓTICO, BARCELONA"
   },
   "manifesto": {
     "header": "Manifiesto",

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,8 +1,9 @@
+import { SpaceProps, TypographyProps, space, typography } from "styled-system";
+
+import Flex from "./Flex";
 import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import { space, typography, SpaceProps, TypographyProps } from "styled-system";
-import Flex from "./Flex";
 
 type ContactPageProps = SpaceProps & TypographyProps;
 
@@ -12,11 +13,6 @@ const Container = styled.div<ContactPageProps>`
 `;
 
 const H1 = styled.h1<ContactPageProps>`
-  ${space};
-  ${typography};
-`;
-
-const H2 = styled.h2<ContactPageProps>`
   ${space};
   ${typography};
 `;
@@ -31,23 +27,13 @@ const Contact = () => {
   const fontSizes = [2, 3, 4, 5];
   return (
     <Flex flex="auto" alignItems="center">
-      <Container textAlign="justify">
+      <Container>
         <H1 fontSize={[4, 5, 6, 7]} py={3}>
           {t("contact.header")}
         </H1>
-        <H2 fontSize={fontSizes} py={3}>
-          {t("contact.subheader")}
-        </H2>
-        <ContactInfo fontSize={fontSizes} py={1}>
-          <a
-            href="mailto:ox@oxymore.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t("contact.email")}
-          </a>
+        <ContactInfo fontSize={fontSizes} py={3}>
+          {t("contact.contact-info")}
         </ContactInfo>
-        <ContactInfo fontSize={fontSizes}>{t("contact.location")}</ContactInfo>
       </Container>
     </Flex>
   );


### PR DESCRIPTION
### What changes have you made?

- replaced the placeholder text on the contact page 
- no translation provided so removed unused translation objects 

### Which issue(s) does this PR fix?

Fixes #271

### Screenshots (if there are design changes)
<img width="247" alt="Screenshot 2020-12-04 at 14 23 46" src="https://user-images.githubusercontent.com/53219789/101168934-83141080-363c-11eb-8f5c-7e4938feab74.png">


### How to test
Go to the contact page and check that the text is updated 