### PR TITLE
updates translation functionality

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -14,11 +14,12 @@
   },
   "contact": {
     "header": "Contact",
-    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM BASED IN GÓTICO, BARCELONA"
+    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM <br> BASED IN GÓTICO, BARCELONA"
   },
   "manifesto": {
     "header": "Manifesto",
-    "manifesto": "Classy anarchist connections make for genuinely diverse utopias in which noble social fights by minorities educate the ignorant and empower the humble and naïf. An oniric queer love revolution, elegantly kitsch and subtly absurd. An anti design dystopia created by aesthetic oxymorons."
+    "left-column": "Classy anarchist connections make for genuinely diverse utopias in which noble social fights by minorities educate the ignorant and empower the humble and naïf. An oniric queer love revolution, elegantly kitsch and subtly absurd. An anti design dystopia created by aesthetic oxymorons.",
+    "right-column": "Conexiones anarquistas distinguidas crean utopías genuinamente diversas en las que las nobles luchas sociales de las minorías educan a los ignorantes y dan poder a los humildes e ingenuos. Una onírica revolución de amor queer, elegantemente kitsch y sutilmente absurda. Una distopía anti-diseño creada por oximoron estéticos."
   },
   "about": {
     "header": "About",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -18,7 +18,8 @@
   },
   "manifesto": {
     "header": "Manifiesto",
-    "manifesto": "Conexiones anarquistas distinguidas crean utopías genuinamente diversas en las que las nobles luchas sociales de las minorías educan a los ignorantes y dan poder a los humildes e ingenuos. Una onírica revolución de amor queer, elegantemente kitsch y sutilmente absurda. Una distopía anti-diseño creada por oximoron estéticos."
+    "left-column": "Conexiones anarquistas distinguidas crean utopías genuinamente diversas en las que las nobles luchas sociales de las minorías educan a los ignorantes y dan poder a los humildes e ingenuos. Una onírica revolución de amor queer, elegantemente kitsch y sutilmente absurda. Una distopía anti-diseño creada por oximoron estéticos.",
+    "right-column": "Classy anarchist connections make for genuinely diverse utopias in which noble social fights by minorities educate the ignorant and empower the humble and naïf. An oniric queer love revolution, elegantly kitsch and subtly absurd. An anti design dystopia created by aesthetic oxymorons."
   },
   "about": {
     "header": "Sobre nosotros",

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -1,9 +1,10 @@
+import { SpaceProps, TypographyProps, space, typography } from "styled-system";
+
+import Flex from "./Flex";
+import Grid from "./Grid";
 import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import { space, typography, SpaceProps, TypographyProps } from "styled-system";
-import Grid from "./Grid";
-import Flex from "./Flex";
 
 type ManifestoProps = TypographyProps & SpaceProps;
 
@@ -41,10 +42,10 @@ const Manifesto = () => {
         ]}
       >
         <Paragraph pb={5} fontSize={fontSizes}>
-          {t("manifesto.manifesto")}
+          {t("manifesto.left-column")}
         </Paragraph>
         <Paragraph pb={5} fontSize={fontSizes}>
-          {t("manifesto.manifesto")}
+          {t("manifesto.right-column")}
         </Paragraph>
       </Grid>
     </Flex>


### PR DESCRIPTION
### What changes have you made?

- I've renamed the keys in the translation JSON to `left-column` and `right-column` so that we can use English and Spanish in both columns

### Which issue(s) does this PR fix?

Fixes #275 

### Screenshots (if there are design changes)
No design changes just both translations on view 


### How to test
Go to `http://localhost:3000/manifesto` and check that the translation works on both columns 