### PR TITLE
So/add text about page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -22,7 +22,8 @@
   },
   "about": {
     "header": "About",
-    "subheader": "Oxymore Magazine is a print and online platform that seeks to raise awareness about current social issues, and connects collectives in a situation of vulnerability with artists, in order to generate visibility and empowerment through artistic multimedia experimentation."
+    "subheader": "Our team",
+    "summary": "Oxymore Magazine is a print and online platform that seeks to raise awareness about current social issues, and connects collectives in a situation of vulnerability with artists, in order to generate visibility and empowerment through artistic multimedia experimentation."
   },
   "advertising": {
     "salazraki": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -22,8 +22,8 @@
   },
   "about": {
     "header": "About",
-    "subheader": "Our team",
-    "summary": "Oxymore Magazine is a print and online platform that seeks to raise awareness about current social issues, and connects collectives in a situation of vulnerability with artists, in order to generate visibility and empowerment through artistic multimedia experimentation."
+    "summary": "Oxymore Magazine is a print and online platform that seeks to raise awareness about current social issues, and connects collectives in a situation of vulnerability with artists, in order to generate visibility and empowerment through artistic multimedia experimentation.",
+    "team": "OUR TEAM AITOR COSTA EDITOR-IN-CHIEF MICAELA RUIZ MANAGING EDITOR RODRIGO AGUDO HEAD OF COMMUNICATION OLGA PIPNIK ART DIRECTOR JUAN CAMILO RODRIGUEZ FASHION EDITOR GLORIA FERRER EXECUTIVE EDITOR NIL FERNÁNDEZ GRAPHIC DESIGNER"
   },
   "advertising": {
     "salazraki": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -22,7 +22,8 @@
   },
   "about": {
     "header": "Sobre nosotros",
-    "subheader": "Oxymore Magazine es una plataforma en formato de revista impresa y online, que busca crear conciencia hacia temas sociales actuales; y que conecta a colectivos en una situación de vulnerabilidad o temáticas de problemática actual con artistas; con el fin de generar visibilidad y empoderamiento a través de la experimentación artística multimedia."
+    "subheader": "Nuestro equipo",
+    "summary": "Oxymore Magazine es una plataforma en formato de revista impresa y online, que busca crear conciencia hacia temas sociales actuales; y que conecta a colectivos en una situación de vulnerabilidad o temáticas de problemática actual con artistas; con el fin de generar visibilidad y empoderamiento a través de la experimentación artística multimedia."
   },
   "conscious-shopping": {
     "subheader": "Hay muchas variaciones de los pasajes de Lorem Ipsum disponibles",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -22,8 +22,8 @@
   },
   "about": {
     "header": "Sobre nosotros",
-    "subheader": "Nuestro equipo",
-    "summary": "Oxymore Magazine es una plataforma en formato de revista impresa y online, que busca crear conciencia hacia temas sociales actuales; y que conecta a colectivos en una situación de vulnerabilidad o temáticas de problemática actual con artistas; con el fin de generar visibilidad y empoderamiento a través de la experimentación artística multimedia."
+    "summary": "Oxymore Magazine es una plataforma en formato de revista impresa y online, que busca crear conciencia hacia temas sociales actuales; y que conecta a colectivos en una situación de vulnerabilidad o temáticas de problemática actual con artistas; con el fin de generar visibilidad y empoderamiento a través de la experimentación artística multimedia.",
+    "team": "NUESTRO EQUIPO AITOR COSTA EDITOR-IN-CHIEF MICAELA RUIZ MANAGING EDITOR RODRIGO AGUDO HEAD OF COMMUNICATION OLGA PIPNIK ART DIRECTOR JUAN CAMILO RODRIGUEZ FASHION EDITOR GLORIA FERRER EXECUTIVE EDITOR NIL FERNÁNDEZ GRAPHIC DESIGNER"
   },
   "conscious-shopping": {
     "subheader": "Hay muchas variaciones de los pasajes de Lorem Ipsum disponibles",

--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -66,12 +66,6 @@ const H1 = styled.h1<TypographyProps & SpaceProps>`
   ${typography};
 `;
 
-const H2 = styled.h2<TypographyProps & SpaceProps>`
-  text-transform: uppercase;
-  ${space};
-  ${typography};
-`;
-
 const P = styled.p<TypographyProps & SpaceProps>`
   text-transform: uppercase;
   text-align: justify;
@@ -123,9 +117,6 @@ const AboutUs = () => {
       <P fontSize={4} mb={4} lineHeight={1.5}>
         {t("about.summary")}
       </P>
-      <H2 fontSize={4} mb={4}>
-        {t("about.subheader")}
-      </H2>
       <Grid
         gridRowGap={[1, 1, 1, 0]}
         gridTemplateColumns={[
@@ -144,12 +135,7 @@ const AboutUs = () => {
           lineHeight={1.5}
           textAlign="justify"
         >
-          <p>
-            OUR TEAM AITOR COSTA EDITOR-IN-CHIEF MICAELA RUIZ MANAGING EDITOR
-            RODRIGO AGUDO HEAD OF COMMUNICATION OLGA PIPNIK ART DIRECTOR JUAN
-            CAMILO RODRIGUEZ FASHION EDITOR GLORIA FERRER EXECUTIVE EDITOR NIL
-            FERNÁNDEZ GRAPHIC DESIGNER
-          </p>
+          <P>{t("about.team")}</P>
         </GridCell>
       </Grid>
     </Flex>

--- a/src/components/AboutUs.tsx
+++ b/src/components/AboutUs.tsx
@@ -66,23 +66,27 @@ const H1 = styled.h1<TypographyProps & SpaceProps>`
   ${typography};
 `;
 
-const H2 = styled.h1<TypographyProps & SpaceProps>`
+const H2 = styled.h2<TypographyProps & SpaceProps>`
+  text-transform: uppercase;
+  ${space};
+  ${typography};
+`;
+
+const P = styled.p<TypographyProps & SpaceProps>`
   text-transform: uppercase;
   text-align: justify;
   ${space};
   ${typography};
 `;
 
-const Img = styled.img<LayoutProps>`
+const TeamMemberImg = styled.img`
   height: 100%;
   width: 100%;
-  ${layout};
 `;
 
-const TeamMemberContainer = styled.div<LayoutProps>`
+const TeamMemberContainer = styled.div`
   object-fit: contain;
   height: 100%;
-  ${layout};
 `;
 
 const GridCell = styled.div<
@@ -103,7 +107,7 @@ interface TeamMemberProps {
 const TeamMember = ({ name, img, alt }: TeamMemberProps) => {
   return (
     <TeamMemberContainer key={name}>
-      <Img alt={alt} src={img} />
+      <TeamMemberImg alt={alt} src={img} />
     </TeamMemberContainer>
   );
 };
@@ -116,7 +120,10 @@ const AboutUs = () => {
       <H1 fontSize={5} mb={4}>
         {t("about.header")}
       </H1>
-      <H2 fontSize={5} mb={4}>
+      <P fontSize={4} mb={4} lineHeight={1.5}>
+        {t("about.summary")}
+      </P>
+      <H2 fontSize={4} mb={4}>
         {t("about.subheader")}
       </H2>
       <Grid


### PR DESCRIPTION
### What changes have you made?

- added translatable text to team section in the last grid cell 
- reduced the font size slightly on the summary at the top as it was taking up a lot of space
- removed unused props

### Which issue(s) does this PR fix?

Fixes #279 

### Screenshots (if there are design changes)
<img width="1437" alt="Screenshot 2020-12-08 at 14 42 36" src="https://user-images.githubusercontent.com/53219789/101491318-e4512200-3963-11eb-9561-0377e401d24d.png">

### How to test
Go to `localhost:3000/about` and check that the team section in the last grid cell is translatable 