### PR TITLE
adds margins advertising, about and manifesto pages

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -14,7 +14,8 @@
   },
   "contact": {
     "header": "Contact",
-    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM <br> BASED IN GÓTICO, BARCELONA"
+    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM ",
+    "location-info": "BASED IN GÓTICO, BARCELONA"
   },
   "manifesto": {
     "header": "Manifesto",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -14,7 +14,8 @@
   },
   "contact": {
     "header": "Contácto",
-    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM BASED IN GÓTICO, BARCELONA"
+    "contact-info": "FOR INQUIRIES PLEASE CONTACT OX@OXYMOREMAGAZINE.COM BASED IN GÓTICO, BARCELONA",
+    "location-info": "BASED IN GÓTICO, BARCELONA"
   },
   "manifesto": {
     "header": "Manifiesto",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,5 @@
-import React, { Suspense } from "react";
-import GlobalStyle from "./GlobalStyle";
-import { ThemeProvider } from "styled-components";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import theme from "./components/theme";
 import "./css/reset.css";
-import Header from "./components/Header";
-import Loading from "./components/Loading";
-import Home from "./components/Home";
-import Projects from "./components/Projects";
-import Contact from "./components/Contact";
-import AboutUs from "./components/AboutUs";
-import Manifesto from "./components/Manifesto";
-import Advertising from "./components/Advertising";
-import ConsciousShopping from "./components/project-pages/ConsciousShopping";
-import MarcMedina from "./components/project-pages/MarcMedina";
-import Belledejour from "./components/project-pages/Belledejour";
-import Eye from "./components/project-pages/Eye";
-import LeoAdef from "./components/project-pages/LeoAdef";
-import EroticStories from "./components/project-pages/EroticStories";
-import Map from "./components/project-pages/Map";
-import KaiLandre from "./components/project-pages/KaiLandre";
-import FashionEditorial from "./components/project-pages/FashionEditorial";
-import Background from "./components/Background";
-import Error404 from "./components/Error404";
-import Flex from "./components/Flex";
+
 import {
   ABOUT_URL,
   ADVERTISING_URL,
@@ -41,6 +17,32 @@ import {
   OXYMORE_URL,
   PROJECTS_URL,
 } from "./constants/router-urls";
+import React, { Suspense } from "react";
+import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
+
+import AboutUs from "./components/About";
+import Advertising from "./components/Advertising";
+import Background from "./components/Background";
+import Belledejour from "./components/project-pages/Belledejour";
+import ConsciousShopping from "./components/project-pages/ConsciousShopping";
+import Contact from "./components/Contact";
+import EroticStories from "./components/project-pages/EroticStories";
+import Error404 from "./components/Error404";
+import Eye from "./components/project-pages/Eye";
+import FashionEditorial from "./components/project-pages/FashionEditorial";
+import Flex from "./components/Flex";
+import GlobalStyle from "./GlobalStyle";
+import Header from "./components/Header";
+import Home from "./components/Home";
+import KaiLandre from "./components/project-pages/KaiLandre";
+import LeoAdef from "./components/project-pages/LeoAdef";
+import Loading from "./components/Loading";
+import Manifesto from "./components/Manifesto";
+import Map from "./components/project-pages/Map";
+import MarcMedina from "./components/project-pages/MarcMedina";
+import Projects from "./components/Projects";
+import { ThemeProvider } from "styled-components";
+import theme from "./components/theme";
 
 const App = () => {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
 import React, { Suspense } from "react";
 import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 
-import AboutUs from "./components/About";
+import About from "./components/About";
 import Advertising from "./components/Advertising";
 import Background from "./components/Background";
 import Belledejour from "./components/project-pages/Belledejour";
@@ -57,7 +57,7 @@ const App = () => {
                 <Route path={OXYMORE_URL} exact component={Home} />
                 <Route path={CONTACT_URL} exact component={Contact} />
                 <Route path={MANIFESTO_URL} exact component={Manifesto} />
-                <Route path={ABOUT_URL} exact component={AboutUs} />
+                <Route path={ABOUT_URL} exact component={About} />
                 <Route path={ADVERTISING_URL} exact component={Advertising} />
                 <Route path={PROJECTS_URL} exact component={Projects} />
                 <Route path={MARC_MEDINA_URL} exact component={MarcMedina} />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -106,15 +106,15 @@ const TeamMember = ({ name, img, alt }: TeamMemberProps) => {
   );
 };
 
-const AboutUs = () => {
+const About = () => {
   const { t } = useTranslation();
 
   return (
     <Flex flex="auto" flexDirection="column">
-      <H1 fontSize={5} mb={4}>
+      <H1 fontSize={[4, 5, 5, 6]} my={4}>
         {t("about.header")}
       </H1>
-      <P fontSize={4} mb={4} lineHeight={1.5}>
+      <P fontSize={[4, 4, 4, 5]} mb={4} lineHeight={1.5}>
         {t("about.summary")}
       </P>
       <Grid
@@ -142,4 +142,4 @@ const AboutUs = () => {
   );
 };
 
-export default AboutUs;
+export default About;

--- a/src/components/Advertising.tsx
+++ b/src/components/Advertising.tsx
@@ -39,6 +39,7 @@ const Advertising: React.FC = () => {
       flex="auto"
       flexDirection={["column", "column", "column", "row"]}
       justifyContent="center"
+      mt={4}
     >
       <Flex
         flex="auto"

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -7,34 +7,34 @@ import { useTranslation } from "react-i18next";
 
 type ContactPageProps = SpaceProps & TypographyProps;
 
-const Container = styled.div<ContactPageProps>`
-  ${typography};
-  text-transform: uppercase;
-`;
-
 const H1 = styled.h1<ContactPageProps>`
   ${space};
   ${typography};
+  text-transform: uppercase;
 `;
 
 const ContactInfo = styled.p<ContactPageProps>`
   ${space};
   ${typography};
+  text-transform: uppercase;
 `;
 
 const Contact = () => {
   const { t } = useTranslation();
-  const fontSizes = [2, 3, 4, 5];
+  const contactInfo = t("contact.contact-info");
+
   return (
     <Flex flex="auto" alignItems="center">
-      <Container>
+      <div>
         <H1 fontSize={[4, 5, 6, 7]} py={3}>
           {t("contact.header")}
         </H1>
-        <ContactInfo fontSize={fontSizes} py={3}>
-          {t("contact.contact-info")}
-        </ContactInfo>
-      </Container>
+        <ContactInfo
+          fontSize={[4, 4, 4, 5]}
+          py={3}
+          dangerouslySetInnerHTML={{ __html: contactInfo }}
+        />
+      </div>
     </Flex>
   );
 };

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -21,7 +21,6 @@ const ContactInfo = styled.p<ContactPageProps>`
 
 const Contact = () => {
   const { t } = useTranslation();
-  const contactInfo = t("contact.contact-info");
 
   return (
     <Flex flex="auto" alignItems="center">
@@ -29,11 +28,12 @@ const Contact = () => {
         <H1 fontSize={[4, 5, 6, 7]} py={3}>
           {t("contact.header")}
         </H1>
-        <ContactInfo
-          fontSize={[4, 4, 4, 5]}
-          py={3}
-          dangerouslySetInnerHTML={{ __html: contactInfo }}
-        />
+        <ContactInfo fontSize={[4, 4, 4, 5]}>
+          {t("contact.contact-info")}
+        </ContactInfo>
+        <ContactInfo fontSize={[4, 4, 4, 5]}>
+          {t("contact.location-info")}
+        </ContactInfo>
       </div>
     </Flex>
   );

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -24,11 +24,10 @@ const Paragraph = styled.p<ManifestoProps>`
 
 const Manifesto = () => {
   const { t } = useTranslation();
-  const fontSizes = [3, 4, 5, 5];
 
   return (
     <Flex flex="auto" flexDirection="column" justifyContent="center">
-      <H1 fontSize={[2, 5]} pb={5}>
+      <H1 fontSize={[4, 5, 5, 6]} my={4}>
         {t("manifesto.header")}
       </H1>
       <Grid
@@ -41,10 +40,10 @@ const Manifesto = () => {
           "repeat(2, 48% [col-start])",
         ]}
       >
-        <Paragraph pb={5} fontSize={fontSizes}>
+        <Paragraph mb={5} fontSize={[4, 4, 4, 5]}>
           {t("manifesto.left-column")}
         </Paragraph>
-        <Paragraph pb={5} fontSize={fontSizes}>
+        <Paragraph mb={5} fontSize={[4, 4, 4, 5]}>
           {t("manifesto.right-column")}
         </Paragraph>
       </Grid>


### PR DESCRIPTION
### What changes have you made?
- applied an equal margin top to the advertising, manifesto and about pages 
- the margins are set from the header to where the content begins, this should give a cleaner look and feel as you switch pages 
- renamed the `About` component (fka `AboutUs`) to be consistent with its pathname `/about` 
- fixed the bug on the contact page with the line break 

### Which issue(s) does this PR fix?

Fixes #282 and #273 

### Screenshots (if there are design changes)
<img width="287" alt="Screenshot 2020-12-09 at 12 14 29" src="https://user-images.githubusercontent.com/53219789/101623015-1b810b00-3a18-11eb-955b-e9a7810e68c9.png">


### How to test
- Check that there is an equal margin top on the advertising, manifesto and about pages
- On the contact page the `<br>` should no longer be visible   