### PR TITLE
updates timer to new launch date

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
 import Flex from "./Flex";
+import React from "react";
 import Timer from "./Timer";
 
 const Loading = () => {
   return (
     <Flex flex="auto" overflow="hidden" justifyContent="center">
-      <Timer launchDate="2020-12-11" />
+      <Timer launchDate="2021-01-08" />
     </Flex>
   );
 };


### PR DESCRIPTION
### What changes have you made?
- updated timer of the `Loading` page to the new launch date of Jan 8th 

Reminder. this will have to be merged into `master` to avoid the site automatically launching in a few hours 

### Which issue(s) does this PR fix?
Fixes #288 

### Screenshots (if there are design changes)
<img width="635" alt="Screenshot 2020-12-10 at 17 00 24" src="https://user-images.githubusercontent.com/53219789/101796480-3da68600-3b09-11eb-8431-4910fbf747a4.png">

### How to test

Go to http://localhost:3000/ and check that the timer is updated 
