### PR TITLE
fixes typo and adjusts timer

### DIFF
--- a/src/components/project-pages/EroticStories.tsx
+++ b/src/components/project-pages/EroticStories.tsx
@@ -11,7 +11,7 @@ const Main = styled(Flex)<TypographyProps>`
   ${typography};
 `;
 
-const launchDate = "2020-01-21";
+const launchDate = "2021-03-21";
 const EroticStories = () => {
   return (
     <Main

--- a/src/components/project-pages/EroticStoriesContent.tsx
+++ b/src/components/project-pages/EroticStoriesContent.tsx
@@ -10,22 +10,21 @@ import {
   space,
   typography,
 } from "styled-system";
-
-import { Link } from "react-router-dom";
 import React, { Fragment } from "react";
+
+import Flex from "../Flex";
+import { Link } from "react-router-dom";
 import bellyButtonsImg from "../assets/erotic-stories/belly-buttons.jpg";
 import statue from "../assets/project-page/statue.png";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import wingsBeatingImg from "../assets/erotic-stories/wings-beating.jpg";
-import Flex from "../Flex";
-
 
 const Img = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
-`
+`;
 const ProjectIcon = styled.img<LayoutProps & FlexboxProps>`
   ${layout};
   ${flexbox};
@@ -93,7 +92,7 @@ const EroticStoriesContent = () => {
               <ProjectIcon
                 src={statue}
                 alt="project icon"
-                maxWidth="10%"
+                maxWidth="15%"
               ></ProjectIcon>
             </Link>
           </IconContainer>
@@ -140,7 +139,7 @@ const EroticStoriesContent = () => {
           width={["100%", "100%", "100%", "50%"]}
           minWidth={["100%", "100%", "100%", "50%"]}
           position={["unset", "unset", "unset", "sticky"]}
-          height={["unsert", "unsert", "unsert", "100vh"]}
+          height={["unset", "unset", "unset", "100vh"]}
           top="0"
         >
           <Img src={bellyButtons.img} alt={bellyButtons.alt} />


### PR DESCRIPTION
### What changes have you made?

- corrected the typo on the height properties of the `<Flex>` on line 138
- set the timer back on the preview page

### Which issue(s) does this PR fix?

Fixes #307 

### Screenshots (if there are design changes)
No design changes

### How to test
Line 142 should now read ` height={["unset", "unset", "unset", "100vh"]}`