### PR TITLE
corrects project icon

### DIFF
--- a/src/components/projects/LeoAdefPreview.tsx
+++ b/src/components/projects/LeoAdefPreview.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { PROJECTS_URL } from "../../constants/router-urls";
 import React from "react";
 import Timer from "../Timer";
-import spider from "./../../assets/project-page/project-icons/shell.png";
+import spider from "./../../assets/project-page/project-icons/spider.png";
 import styled from "styled-components";
 
 const Img = styled.img<LayoutProps>`


### PR DESCRIPTION
### What changes have you made?
- I added the correct project icon to the Leo Adef preview page 

### Which issue(s) does this PR fix?

Fixes #316 

### Screenshots (if there are design changes)

<img width="417" alt="Screenshot 2021-01-05 at 19 41 07" src="https://user-images.githubusercontent.com/53219789/103691381-fa1b2c80-4f8d-11eb-80e5-687e7eb7f741.png">


### How to test

- Go to http://localhost:3000/projects/leoadef and you should see a spider 🕷️
