### PR TITLE
sets timer to launch at 18h 

### DIFF
--- a/src/helpers/calculateTimeLeft.ts
+++ b/src/helpers/calculateTimeLeft.ts
@@ -10,7 +10,7 @@ const calculateTimeLeft = (date: string): TimeLeft => {
     Number(new Date(date).getTime()) - Number(new Date().getTime());
 
   const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24));
-  const hoursLeft = Math.floor(((difference / (1000 * 60 * 60)) % 24) - 1);
+  const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24) + 17;
   const minutesLeft = Math.floor((difference / 1000 / 60) % 60);
   const secondsLeft = Math.floor((difference / 1000) % 60);
 

--- a/src/helpers/calculateTimeLeft.ts
+++ b/src/helpers/calculateTimeLeft.ts
@@ -9,8 +9,8 @@ const calculateTimeLeft = (date: string): TimeLeft => {
   const difference =
     Number(new Date(date).getTime()) - Number(new Date().getTime());
 
-  const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24));
-  const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24) + 17;
+  const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24) + 1);
+  const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24) - 6;
   const minutesLeft = Math.floor((difference / 1000 / 60) % 60);
   const secondsLeft = Math.floor((difference / 1000) % 60);
 


### PR DESCRIPTION
### What changes have you made?
- I've programmed the site to launch on Friday at 18h now that launch time is confirmed 

### Which issue(s) does this PR fix?

Fixes #321

### Screenshots (if there are design changes)
No design changes

### How to test
You can check the calculation by adding the time left as seen on the loading page to the current time on your local machine. 

This should equal 15/01/2021 18.00 hours.

So for example, if we add the current time, 10.30h to the time left which is 3d 7h 30m,  we get Friday 15th, 18.00h 



