### PR TITLE
sets timer so that launch occurs at 18.00h

### DIFF
--- a/src/helpers/calculateTimeLeft.ts
+++ b/src/helpers/calculateTimeLeft.ts
@@ -9,8 +9,8 @@ const calculateTimeLeft = (date: string): TimeLeft => {
   const difference =
     Number(new Date(date).getTime()) - Number(new Date().getTime());
 
-  const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24) + 1);
-  const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24) - 6;
+  const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24));
+  const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24) + 18;
   const minutesLeft = Math.floor((difference / 1000 / 60) % 60);
   const secondsLeft = Math.floor((difference / 1000) % 60);
 


### PR DESCRIPTION
### What changes have you made?
- I spotted an error with the launch date timer soon after #325 was merged so I _think_ I've fixed that now

### Which issue(s) does this PR fix?

Fixes #332 

### Screenshots (if there are design changes)
No design changes

### How to test
Same as before, just make sure that the current time when added to `timeLeft` is equal to 15-01-2021 18.00 hours