### PR TITLE
adjusts stripe redirect to go back to original oxymore page

### DIFF
--- a/src/components/BuyButton.tsx
+++ b/src/components/BuyButton.tsx
@@ -16,6 +16,7 @@ import redirectToCheckout from "../helpers/redirectToCheckout";
 import styled from "styled-components";
 import theme from "./theme";
 import { useTranslation } from "react-i18next";
+import { useLocation } from "react-router-dom";
 
 const Button = styled.button<
   SpaceProps & TypographyProps & BorderProps & BackgroundProps & LayoutProps
@@ -40,13 +41,14 @@ const Button = styled.button<
 const BuyButton: React.FC = () => {
   const [error, setError] = useState<string>();
   const { t } = useTranslation();
+  const { pathname } = useLocation();
 
   return (
     <Fragment>
       {error && <p>{error}</p>}
       <Button
         role="link"
-        onClick={redirectToCheckout(setError)}
+        onClick={redirectToCheckout(setError, pathname)}
         fontSize={[0, 1, 3]}
         background="transparent"
         fontStyle="uppercase"

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -18,7 +18,7 @@ import {
 import React, { Fragment, useCallback, useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import redirectToCheckout from "../helpers/redirectToCheckout";
 import theme from "./theme";
 import { useTranslation } from "react-i18next";
@@ -40,7 +40,7 @@ const overlayStyles = css`
 
 const Overlay = styled.dialog<{ isOpen: boolean }>`
   display: none;
-  ${props => props.isOpen && overlayStyles}
+  ${(props) => props.isOpen && overlayStyles}
 `;
 
 const Menu = styled.ul<TypographyProps & SpaceProps>`
@@ -112,13 +112,14 @@ const Link = ({ page, url, onClick }: LinkProps & { onClick: () => void }) => {
 const StripeMenuLink: React.FC = () => {
   const [error, setError] = useState<string>();
   const { t } = useTranslation();
+  const { pathname } = useLocation();
 
   return (
     <Fragment>
       {error && <p>{error}</p>}
       <MenuItem>
         <BuyLink
-          onClick={redirectToCheckout(setError)}
+          onClick={redirectToCheckout(setError, pathname)}
           fontSize={[5, 6, 7, 8]}
           color="black"
         >
@@ -194,7 +195,7 @@ const NavMenu = () => {
         </MenuButton>
 
         <Menu textAlign={["center", null, null, "start"]} p={4}>
-          {links.map(props => (
+          {links.map((props) => (
             <Link key={props.page} onClick={toggleMenuIsOpen} {...props} />
           ))}
           <StripeMenuLink />

--- a/src/helpers/redirectToCheckout.ts
+++ b/src/helpers/redirectToCheckout.ts
@@ -3,13 +3,14 @@ import allowedCountries from "../constants/stripe-allowed-countries";
 
 const stripePromise = loadStripe(`${process.env.REACT_APP_STRIPE_API_KEY}`);
 
-const successUrl = `${process.env.REACT_APP_BASE_URL}/oxymore`;
-const cancelUrl = `${process.env.REACT_APP_BASE_URL}/oxymore`;
-
 type SetErrorType = (errorMessage: string) => void;
 
-const redirectToCheckout = (setError: SetErrorType) => async () => {
+const redirectToCheckout = (
+  setError: SetErrorType,
+  redirectUrl: string
+) => async () => {
   try {
+    const urlWhenDone = `${process.env.REACT_APP_BASE_URL}${redirectUrl}`;
     // When the customer clicks on the button, redirect them to Checkout.
     const stripe = await stripePromise;
     if (!stripe) {
@@ -24,8 +25,8 @@ const redirectToCheckout = (setError: SetErrorType) => async () => {
         },
       ],
       mode: "payment",
-      successUrl,
-      cancelUrl,
+      successUrl: urlWhenDone,
+      cancelUrl: urlWhenDone,
       shippingAddressCollection: {
         allowedCountries,
       },


### PR DESCRIPTION
### What changes have you made?

- uses current `location.pathname` for redirect urls when returning from Stripe payment

### Which issue(s) does this PR fix?

Fixes #299 

### How to test

- go to a project page
- open nav menu
- click buy
- on stripe click back
- should take you back to the project page