### PR TITLE
creates new price ID for shipping and limits shipping countries to eu…

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -12,17 +12,17 @@ import {
 import BuyButton from "./BuyButton";
 import Flex from "./Flex";
 import LanguageButtons from "./LanguageButtons";
+import Loading from "./Loading";
 import { NavLink } from "react-router-dom";
 import NavMenu from "./NavMenu";
 import { PROJECTS_URL } from "../constants/router-urls";
+import PreviewOrProjectPage from "./projects/PreviewOrProjectPage";
 import React from "react";
 import alpha from "../assets/home-page/360-alpha.png";
 import manifesto from "../assets/home-page/manifesto.png";
 import number from "../assets/home-page/number-one.png";
 import oxymore from "../assets/home-page/oxymore.png";
 import styled from "styled-components";
-import PreviewOrProjectPage from "./projects/PreviewOrProjectPage";
-import Loading from "./Loading";
 
 const ManifestoLink = styled(NavLink)<TypographyProps>`
   ${typography};

--- a/src/constants/stripe-allowed-countries.ts
+++ b/src/constants/stripe-allowed-countries.ts
@@ -1,10 +1,8 @@
+// limited to European countries
 const allowedCountries = [
-  "US",
   "AT",
-  "AU",
   "BE",
   "BG",
-  "CA",
   "CH",
   "CY",
   "CZ",
@@ -16,7 +14,6 @@ const allowedCountries = [
   "FR",
   "GB",
   "GR",
-  "HK",
   "IE",
   "IT",
   "LT",
@@ -25,12 +22,10 @@ const allowedCountries = [
   "MT",
   "NL",
   "NO",
-  "NZ",
   "PL",
   "PT",
   "RO",
   "SE",
-  "SG",
   "SI",
   "SK",
 ];

--- a/src/helpers/redirectToCheckout.ts
+++ b/src/helpers/redirectToCheckout.ts
@@ -20,11 +20,11 @@ const redirectToCheckout = (
     await stripe.redirectToCheckout({
       lineItems: [
         {
-          price: `${process.env.REACT_APP_STRIPE_PRICE_ID_1}`,
+          price: `${process.env.REACT_APP_STRIPE_MAGAZINE_PRICE_ID}`,
           quantity: 1,
         },
         {
-          price: `${process.env.REACT_APP_STRIPE_PRICE_ID_2}`,
+          price: `${process.env.REACT_APP_STRIPE_SHIPPING_PRICE_ID}`,
           quantity: 1,
         },
       ],

--- a/src/helpers/redirectToCheckout.ts
+++ b/src/helpers/redirectToCheckout.ts
@@ -1,5 +1,5 @@
-import { loadStripe } from "@stripe/stripe-js";
 import allowedCountries from "../constants/stripe-allowed-countries";
+import { loadStripe } from "@stripe/stripe-js";
 
 const stripePromise = loadStripe(`${process.env.REACT_APP_STRIPE_API_KEY}`);
 
@@ -20,7 +20,11 @@ const redirectToCheckout = (
     await stripe.redirectToCheckout({
       lineItems: [
         {
-          price: `${process.env.REACT_APP_STRIPE_PRICE_ID}`,
+          price: `${process.env.REACT_APP_STRIPE_PRICE_ID_1}`,
+          quantity: 1,
+        },
+        {
+          price: `${process.env.REACT_APP_STRIPE_PRICE_ID_2}`,
           quantity: 1,
         },
       ],


### PR DESCRIPTION
### What changes have you made?
- reduced the `stripe-allowed-countries` list to European countries only 
- added a new key to the .env file called `REACT_APP_STRIPE_PRICE_ID_2` to give us access to the shipping value 
- the original product now has a key of `REACT_APP_STRIPE_PRICE_ID_1`
- I've made the necessary updates in Heroku with the "Live" values

### Screenshots (if there are design changes)
<img width="1304" alt="Screenshot 2021-01-14 at 20 47 54" src="https://user-images.githubusercontent.com/53219789/104647447-cafd6d00-56a9-11eb-85f2-b29d9b4b58a8.png">


### How to test
- change date on Home to be a date in the past and the content should appear
- click on the buy button the total should be €60
- only Europen countries should appear in the dropdown list 