### PR TITLE
fixes success and cancel redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   EROTIC_STORIES_URL,
   EYES_URL,
   FASHION_EDITORIAL_URL,
+  HOME_URL,
   KAI_LANDRE_URL,
   LEO_ADEF_URL,
   MANIFESTO_URL,
@@ -51,7 +52,7 @@ const App = () => {
             <Suspense fallback={<div>Loading</div>}>
               <Header />
               <Switch>
-                <Route path="/" exact component={Home} />
+                <Route path={HOME_URL} exact component={Home} />
                 <Route path={CONTACT_URL} exact component={Contact} />
                 <Route path={MANIFESTO_URL} exact component={Manifesto} />
                 <Route path={ABOUT_URL} exact component={About} />

--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -7,6 +7,7 @@ import {
   EROTIC_STORIES_URL,
   EYES_URL,
   FASHION_EDITORIAL_URL,
+  HOME_URL,
   KAI_LANDRE_URL,
   LEO_ADEF_URL,
   MANIFESTO_URL,
@@ -36,11 +37,11 @@ const BackgroundElement = styled.div<{ background: Background }>`
   background-size: cover;
   height: 100%;
   z-index: ${theme.zIndexes.behind};
-  ${(props) =>
+  ${props =>
     props.background === `${black}`
       ? `background-color: ${black}`
       : `background: url(${props.background});`}
-  ${(props) =>
+  ${props =>
     props.background === eyeProjectBackground && eyeInteractionBackgroundStyles}
 `;
 
@@ -49,7 +50,7 @@ const eyeInteractionBackgroundStyles = css`
 `;
 
 const getBackground = (pathname: string): Background => {
-  const pagesWithMarbleBG = ["/", PROJECTS_URL];
+  const pagesWithMarbleBG = [HOME_URL, PROJECTS_URL];
   const pagesWithBlackBG = [
     MANIFESTO_URL,
     ADVERTISING_URL,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ import {
 import { NavLink, useLocation } from "react-router-dom";
 
 import Flex from "./Flex";
+import { HOME_URL } from "../constants/router-urls";
 import LanguageButtons from "./LanguageButtons";
 import NavMenu from "./NavMenu";
 import React from "react";
@@ -31,7 +32,7 @@ const HeaderLogo = () => {
   const fontSizes = [1, 2, 3, 4];
 
   return (
-    <NavLink to="/">
+    <NavLink to={HOME_URL}>
       <H1 fontSize={fontSizes}>OXYMORE</H1>
     </NavLink>
   );
@@ -40,7 +41,7 @@ const HeaderLogo = () => {
 const Header = () => {
   const location = useLocation();
 
-  if (location.pathname === "/") {
+  if (location.pathname === `${HOME_URL}`) {
     return null;
   }
 

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -2,6 +2,7 @@ import {
   ABOUT_URL,
   ADVERTISING_URL,
   CONTACT_URL,
+  HOME_URL,
   MANIFESTO_URL,
 } from "../constants/router-urls";
 import {
@@ -14,10 +15,10 @@ import {
   space,
   typography,
 } from "styled-system";
+import { NavLink, useLocation } from "react-router-dom";
 import React, { Fragment, useCallback, useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { NavLink, useLocation } from "react-router-dom";
 import redirectToCheckout from "../helpers/redirectToCheckout";
 import theme from "./theme";
 import { useTranslation } from "react-i18next";
@@ -39,7 +40,7 @@ const overlayStyles = css`
 
 const Overlay = styled.dialog<{ isOpen: boolean }>`
   display: none;
-  ${(props) => props.isOpen && overlayStyles}
+  ${props => props.isOpen && overlayStyles}
 `;
 
 const Menu = styled.ul<TypographyProps & SpaceProps>`
@@ -181,11 +182,10 @@ const NavMenu = () => {
           color={`${theme.colors.copyTwo}`}
           onClick={() => setIsOpen(!isOpen)}
         >
-          <HomepageLink color="black" to="/">
+          <HomepageLink color="black" to={HOME_URL}>
             OXYMORE
           </HomepageLink>
         </MenuButton>
-
         <MenuButton
           onClick={() => setIsOpen(false)}
           fontSize={fontSizes}
@@ -196,9 +196,8 @@ const NavMenu = () => {
         >
           BACK
         </MenuButton>
-
         <Menu textAlign={["center", null, null, "start"]} p={4}>
-          {links.map((props) => (
+          {links.map(props => (
             <Link key={props.page} onClick={toggleMenuIsOpen} {...props} />
           ))}
           <StripeMenuLink />

--- a/src/constants/router-urls.ts
+++ b/src/constants/router-urls.ts
@@ -1,3 +1,4 @@
+export const HOME_URL = "/";
 export const PROJECTS_URL = "/projects";
 export const ABOUT_URL = "/about";
 export const CONTACT_URL = "/contact";


### PR DESCRIPTION
### What changes have you made?
- After deprecating `/oxymore` it muddled up the `urlWhenDone` on the `redirectToCheckout` helper leaving us with this when clicking back:

<img width="640" alt="Screenshot 2021-01-14 at 22 24 02" src="https://user-images.githubusercontent.com/53219789/104656508-5c271080-56b7-11eb-90b8-5056f636eae1.png">

- Better that we work with one source of truth so I've created a `HOME_URL` in the `router-urls.ts` 
- I then found the cause of the problem in the `.env` where `REACT_APP_BASE_URL=http://localhost:3000/` 
- Once the unnecessary `/` was removed I did a test to make sure it really was the cause of the problem:

<img width="640" alt="Screenshot 2021-01-14 at 22 17 31" src="https://user-images.githubusercontent.com/53219789/104656922-04d57000-56b8-11eb-9e22-30977a663b12.png">

And yes, it was 

### Which issue(s) does this PR fix?
Fixes #341 

### How to test
- change date on Home to be a date in the past and the content should appear
- click on the buy button from the Home page 
- cancel the purchase and go back, you should be redirected to the home page 
- make the same test for the projects page 
