### PR TITLE
removes shipping price id

### DIFF
--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -54,7 +54,7 @@ const MenuButton = styled.button<TypographyProps & PositionProps & ColorProps>`
   transition: transform 0.3s;
   &:hover {
     transform: scale(1.01);
-    color: ${theme.colors.copyOne};
+    color: white;
   }
   ${typography};
   ${position};

--- a/src/helpers/redirectToCheckout.ts
+++ b/src/helpers/redirectToCheckout.ts
@@ -23,10 +23,6 @@ const redirectToCheckout = (
           price: `${process.env.REACT_APP_STRIPE_MAGAZINE_PRICE_ID}`,
           quantity: 1,
         },
-        {
-          price: `${process.env.REACT_APP_STRIPE_SHIPPING_PRICE_ID}`,
-          quantity: 1,
-        },
       ],
       mode: "payment",
       successUrl: urlWhenDone,


### PR DESCRIPTION
### What changes have you made?

- removed `REACT_APP_STRIPE_SHIPPING_PRICE_ID` from the `lineItems` array to enable the image to display at full width on the Stripe checkout 
- created a new price in the Stripe dashboard that states shipping included
- updated the live key and value on Heroku 


### Which issue(s) does this PR fix?

Fixes #348 

### Screenshots (if there are design changes)

Before:

<img width="1439" alt="Screenshot 2021-01-15 at 12 44 23" src="https://user-images.githubusercontent.com/53219789/104732429-245eae00-5735-11eb-9fe9-11f1afe25b28.png">

After:

<img width="1439" alt="Screenshot 2021-01-15 at 13 31 49" src="https://user-images.githubusercontent.com/53219789/104733061-0ba2c800-5736-11eb-8003-95326846de64.png">



### How to test
- Click on the buy button from either the projects or nav menu 
- Check that the price is 60 EUR and the description says shipping included
- There should be no separate shipping value
