### PR TITLE
So/update link kai landre

### DIFF
--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -33,9 +33,10 @@ const BackgroundElement = styled.div<{ background: Background }>`
   right: 0;
   bottom: 0;
   left: 0;
-  background-repeat: repeat-y;
+  background-repeat: no-repeat;
   background-size: cover;
   height: 100%;
+  width: 100%;
   z-index: ${theme.zIndexes.behind};
   ${props =>
     props.background === `${black}`
@@ -82,7 +83,7 @@ const Background: React.FC = ({ children }) => {
   const background = getBackground(location.pathname);
 
   return (
-    <Flex flex="auto" flexDirection="column">
+    <Flex flex="auto">
       <BackgroundElement background={background} />
       {children}
     </Flex>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,10 +24,6 @@ const H1 = styled.h1<SpaceProps & TypographyProps & GridProps>`
   }
 `;
 
-const Container = styled.div<LayoutProps>`
-  ${layout};
-`;
-
 const HeaderLogo = () => {
   const fontSizes = [1, 2, 3, 4];
 
@@ -53,10 +49,10 @@ const Header = () => {
       pb={6}
     >
       <HeaderLogo />
-      <Container display="flex">
+      <Flex>
         <LanguageButtons />
         <NavMenu />
-      </Container>
+      </Flex>
     </Flex>
   );
 };

--- a/src/components/projects/kai-landre/KaiLandre.tsx
+++ b/src/components/projects/kai-landre/KaiLandre.tsx
@@ -51,7 +51,7 @@ const KaiLandreContent = () => {
   );
 };
 
-const launchDate = "2020-01-22";
+const launchDate = "2021-01-22";
 const KaiLandre = () => {
   return (
     <Flex flex="auto">

--- a/src/components/projects/kai-landre/KaiLandre.tsx
+++ b/src/components/projects/kai-landre/KaiLandre.tsx
@@ -20,30 +20,29 @@ const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   }
 `;
 
-const KaiLandreContent: React.FC = () => {
+const KaiLandreContent = () => {
   const url = "https://www.youtube.com/watch?v=AGSH_acR4wA";
 
   return (
     <Fragment>
-      <Flex flex="auto" height="100%" width="100%">
+      <Flex flex="auto" height={["60vh", "60vh", "60vh", "80vh"]}>
         <ReactPlayer
           url={url}
+          position="relative"
+          width="100%"
+          height="100%"
           controls
           playing
           muted
-          height="100%"
-          width="100%"
-          position="relative"
-          zIndex={theme.zIndexes.behind}
+          zindex={theme.zIndexes.behind}
         ></ReactPlayer>
         <ReturnToProjectsPage
           to={PROJECTS_URL}
-          maxWidth={80}
-          zIndex={theme.zIndexes.inFront}
+          width={80}
           position="absolute"
-          display={["none", "none", "none", "block"]}
-          right={100}
-          bottom={20}
+          right={60}
+          bottom={100}
+          display={["none", "none", "block", "block"]}
         >
           <img src={dragon} alt="dragon icon" />
         </ReturnToProjectsPage>
@@ -55,7 +54,7 @@ const KaiLandreContent: React.FC = () => {
 const launchDate = "2020-01-22";
 const KaiLandre = () => {
   return (
-    <Flex flex="auto" height={theme.heights.belowHeader} width="100%">
+    <Flex flex="auto">
       <PreviewOrProjectPage
         launchDate={launchDate}
         PreviewPage={KaiLandrePreview}

--- a/src/components/projects/kai-landre/KaiLandre.tsx
+++ b/src/components/projects/kai-landre/KaiLandre.tsx
@@ -1,23 +1,61 @@
+import { LayoutProps, PositionProps, layout, position } from "styled-system";
+import React, { Fragment } from "react";
+
 import Flex from "../../Flex";
 import KaiLandrePreview from "./KaiLandrePreview";
+import { Link } from "react-router-dom";
+import { PROJECTS_URL } from "../../../constants/router-urls";
 import PreviewOrProjectPage from "../PreviewOrProjectPage";
-import React from "react";
 import ReactPlayer from "react-player/lazy";
+import dragon from "../../../assets/project-page/project-icons/dragon.png";
+import styled from "styled-components";
+import theme from "../../theme";
+
+const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
+  ${layout};
+  ${position};
+  transition: transform 0.5s;
+  &:hover {
+    transform: scale(1.02);
+  }
+`;
 
 const KaiLandreContent: React.FC = () => {
   const url = "https://www.youtube.com/watch?v=AGSH_acR4wA";
 
   return (
-    <Flex flex="auto">
-      <ReactPlayer url={url} flex="auto" width="100%" />
-    </Flex>
+    <Fragment>
+      <Flex flex="auto" height="100%" width="100%">
+        <ReactPlayer
+          url={url}
+          controls
+          playing
+          muted
+          height="100%"
+          width="100%"
+          position="relative"
+          zIndex={theme.zIndexes.behind}
+        ></ReactPlayer>
+        <ReturnToProjectsPage
+          to={PROJECTS_URL}
+          maxWidth={80}
+          zIndex={theme.zIndexes.inFront}
+          position="absolute"
+          display={["none", "none", "none", "block"]}
+          right={100}
+          bottom={20}
+        >
+          <img src={dragon} alt="dragon icon" />
+        </ReturnToProjectsPage>
+      </Flex>
+    </Fragment>
   );
 };
 
-const launchDate = "2021-01-22";
+const launchDate = "2020-01-22";
 const KaiLandre = () => {
   return (
-    <Flex flex="auto" justifyContent="center" alignItems="center">
+    <Flex flex="auto" height={theme.heights.belowHeader} width="100%">
       <PreviewOrProjectPage
         launchDate={launchDate}
         PreviewPage={KaiLandrePreview}

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -64,10 +64,6 @@ const borders = {
   whiteThin: "1px solid white",
 };
 
-const heights = {
-  belowHeader: "calc(100vh - 24px)",
-};
-
 const theme = {
   space: {
     ...space,
@@ -85,9 +81,6 @@ const theme = {
   },
   zIndexes: {
     ...zIndexes,
-  },
-  heights: {
-    ...heights,
   },
 };
 

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -64,6 +64,10 @@ const borders = {
   whiteThin: "1px solid white",
 };
 
+const heights = {
+  belowHeader: "calc(100vh - 24px)",
+};
+
 const theme = {
   space: {
     ...space,
@@ -81,6 +85,9 @@ const theme = {
   },
   zIndexes: {
     ...zIndexes,
+  },
+  heights: {
+    ...heights,
   },
 };
 

--- a/src/helpers/calculateTimeLeft.ts
+++ b/src/helpers/calculateTimeLeft.ts
@@ -6,12 +6,12 @@ export interface TimeLeft {
 }
 
 const calculateTimeLeft = (date: string): TimeLeft => {
-  // +17 hours is so that the countdown ends at 6pm on the launchDate shown
+  // +12 hours is so that the countdown ends at 1pm CET on the launchDate shown
   const hourInMilliseconds = 60 * 60 * 1000;
   const difference =
     Number(new Date(date).getTime()) -
     Number(new Date().getTime()) +
-    17 * hourInMilliseconds;
+    12 * hourInMilliseconds;
 
   const daysLeft = Math.floor(difference / (1000 * 60 * 60 * 24));
   const hoursLeft = Math.floor((difference / (1000 * 60 * 60)) % 24);

--- a/src/helpers/calculateTimeLeft.ts
+++ b/src/helpers/calculateTimeLeft.ts
@@ -6,7 +6,7 @@ export interface TimeLeft {
 }
 
 const calculateTimeLeft = (date: string): TimeLeft => {
-  // +12 hours is so that the countdown ends at 1pm CET on the launchDate shown
+  // +12 hours is so that the countdown ends at +13 hours CET on the launchDate shown
   const hourInMilliseconds = 60 * 60 * 1000;
   const difference =
     Number(new Date(date).getTime()) -


### PR DESCRIPTION
### What changes have you made?

- set the timer back to 12.00h GMT which is equal to 13.00h CET 
- added the dragon icon to the `KaiLandreContent` component to allow the user to navigate back to the projects page 
- included some additional props in the `ReactPlayer`: `controls` to allow the user to play, pause and fast forward, `playing` to set the video to autoplay and `muted` to, well.. save the developer's sanity from having to hear the same song over and over
- Aitor flagged an issue on the background image which was seen to be repeating itself on his friend's computer, I don't have a solution for this but in any case, I've removed the `background-repeat` attribute from the background component 

### Which issue(s) does this PR fix?

Fixes #8 
Fixes #357 

### Screenshots (if there are design changes)


### How to test
- Go to the Kai Landre component and set the time back to a date in the past to display the content
- Check that the video auto-plays 
- Check that you can use the controls on the YouTube player 
- Note. Fullscreen doesn't work on mobile. I've tried using [Screenfull](https://www.npmjs.com/package/screenfull-react)  to implement fullscreen but yet to find the right solution. I get the impression it's difficult to override the default Safari player on mobile. Not a requirement but would have been a nice enhancement.
