### PR TITLE
updates youtube url

### DIFF
--- a/src/components/projects/kai-landre/KaiLandre.tsx
+++ b/src/components/projects/kai-landre/KaiLandre.tsx
@@ -1,11 +1,11 @@
 import { LayoutProps, PositionProps, layout, position } from "styled-system";
-import React, { Fragment } from "react";
 
 import Flex from "../../Flex";
 import KaiLandrePreview from "./KaiLandrePreview";
 import { Link } from "react-router-dom";
 import { PROJECTS_URL } from "../../../constants/router-urls";
 import PreviewOrProjectPage from "../PreviewOrProjectPage";
+import React from "react";
 import ReactPlayer from "react-player/lazy";
 import dragon from "../../../assets/project-page/project-icons/dragon.png";
 import styled from "styled-components";
@@ -21,33 +21,30 @@ const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
 `;
 
 const KaiLandreContent = () => {
-  const url = "https://www.youtube.com/watch?v=AGSH_acR4wA";
+  const url = "https://youtu.be/fjnXLRrHscM";
 
   return (
-    <Fragment>
-      <Flex flex="auto" height={["60vh", "60vh", "60vh", "80vh"]}>
-        <ReactPlayer
-          url={url}
-          position="relative"
-          width="100%"
-          height="100%"
-          controls
-          playing
-          muted
-          zindex={theme.zIndexes.behind}
-        ></ReactPlayer>
-        <ReturnToProjectsPage
-          to={PROJECTS_URL}
-          width={80}
-          position="absolute"
-          right={60}
-          bottom={100}
-          display={["none", "none", "block", "block"]}
-        >
-          <img src={dragon} alt="dragon icon" />
-        </ReturnToProjectsPage>
-      </Flex>
-    </Fragment>
+    <Flex flex="auto" height={["76vh", "76vh", "76vh", "80vh", "80vh"]}>
+      <ReactPlayer
+        url={url}
+        position="relative"
+        width="100%"
+        height="100%"
+        controls
+        playing
+        zindex={theme.zIndexes.behind}
+      ></ReactPlayer>
+      <ReturnToProjectsPage
+        to={PROJECTS_URL}
+        width={80}
+        position="absolute"
+        right={60}
+        bottom={100}
+        display={["none", "none", "none", "block"]}
+      >
+        <img src={dragon} alt="dragon icon" />
+      </ReturnToProjectsPage>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
### What changes have you made?
- updated the url of the youtube link which premieres on YouTube at 13.00 CET 

### Which issue(s) does this PR fix?

Fixes #360 

### Screenshots (if there are design changes)
<img width="1440" alt="Screenshot 2021-01-22 at 09 21 49" src="https://user-images.githubusercontent.com/53219789/105474563-46f14980-5c96-11eb-8426-7fedf219bc17.png">


### How to test
- Go to the Kai Landre component and move the launch date back to a date in the past to see the content 
- The following video should appear: https://youtu.be/fjnXLRrHscM