### PR TITLE
So/tweaks

### DIFF
--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -43,22 +43,43 @@ const Overlay = styled.dialog<{ isOpen: boolean }>`
   ${props => props.isOpen && overlayStyles}
 `;
 
-const Menu = styled.ul<TypographyProps & SpaceProps>`
+const OpenNavMenuButton = styled.button<ColorProps & TypographyProps>`
+  ${color};
   ${typography};
-  ${space};
-`;
-
-const MenuButton = styled.button<TypographyProps & PositionProps & ColorProps>`
   border: none;
   background: transparent;
-  transition: transform 0.3s;
+  transition: transform 1s;
   &:hover {
     transform: scale(1.01);
     color: white;
   }
-  ${typography};
-  ${position};
+`;
+
+const BackButton = styled(OpenNavMenuButton)<
+  ColorProps & PositionProps & TypographyProps
+>`
   ${color};
+  ${position};
+  ${typography};
+  &:hover {
+    color: ${theme.colors.copyOne};
+  }
+`;
+
+const ReturnToHomePage = styled(NavLink)<
+  ColorProps & PositionProps & TypographyProps
+>`
+  ${color};
+  ${position};
+  ${typography};
+  &:hover {
+    color: ${theme.colors.copyOne};
+  }
+`;
+
+const Menu = styled.ul<TypographyProps & SpaceProps>`
+  ${typography};
+  ${space};
 `;
 
 const MenuItem = styled.li`
@@ -66,13 +87,6 @@ const MenuItem = styled.li`
   transform-origin: left;
   &:hover {
     transform: scale(1.01);
-  }
-`;
-
-const HomepageLink = styled(NavLink)<ColorProps>`
-  ${color};
-  &:hover {
-    color: ${theme.colors.copyOne};
   }
 `;
 
@@ -84,14 +98,17 @@ const MenuLink = styled(NavLink)<ColorProps & TypographyProps>`
   }
 `;
 
-const BuyLink = styled.button<TypographyProps & ColorProps>`
-  border: none;
-  background: transparent;
-  &:hover {
-    color: ${theme.colors.copyOne};
-  }
+const GoToBuyPage = styled.button<TypographyProps & ColorProps>`
   ${typography};
   ${color};
+  border: none;
+  background: transparent;
+  transition: transform 0.4s;
+  transform-origin: left;
+  &:hover {
+    transform: scale(1.01);
+    color: ${theme.colors.copyOne};
+  }
 `;
 
 interface LinkProps {
@@ -101,11 +118,12 @@ interface LinkProps {
 
 const Link = ({ page, url, onClick }: LinkProps & { onClick: () => void }) => {
   return (
-    <MenuItem onClick={onClick}>
+    <MenuItem>
       <MenuLink
         to={url}
         fontSize={[5, 6, 7, 8]}
         color={`${theme.colors.copyTwo}`}
+        onClick={onClick}
       >
         {page}
       </MenuLink>
@@ -122,13 +140,13 @@ const StripeMenuLink: React.FC = () => {
     <Fragment>
       {error && <p>{error}</p>}
       <MenuItem>
-        <BuyLink
+        <GoToBuyPage
           onClick={redirectToCheckout(setError, pathname)}
           fontSize={[5, 6, 7, 8]}
           color={`${theme.colors.copyTwo}`}
         >
           {t("nav.buy")}
-        </BuyLink>
+        </GoToBuyPage>
       </MenuItem>
     </Fragment>
   );
@@ -170,33 +188,35 @@ const NavMenu = () => {
 
   return (
     <Fragment>
-      <MenuButton onClick={() => setIsOpen(!isOpen)} fontSize={fontSizes}>
+      <OpenNavMenuButton
+        onClick={() => setIsOpen(!isOpen)}
+        fontSize={fontSizes}
+      >
         MENU
-      </MenuButton>
-      <Overlay isOpen={isOpen}>
-        <MenuButton
-          fontSize={fontSizes}
+      </OpenNavMenuButton>
+      <Overlay isOpen={isOpen} onClick={() => setIsOpen(!isOpen)}>
+        <ReturnToHomePage
+          to={HOME_URL}
+          onClick={() => setIsOpen(!isOpen)}
           position="absolute"
           left={24}
           top={24}
-          color={`${theme.colors.copyTwo}`}
-          onClick={() => setIsOpen(!isOpen)}
-        >
-          <HomepageLink color="black" to={HOME_URL}>
-            OXYMORE
-          </HomepageLink>
-        </MenuButton>
-        <MenuButton
-          onClick={() => setIsOpen(false)}
+          color="copyTwo"
           fontSize={fontSizes}
+        >
+          OXYMORE
+        </ReturnToHomePage>
+        <BackButton
+          onClick={() => setIsOpen(!isOpen)}
           position="absolute"
-          right={30}
+          right={24}
           top={24}
-          color={`${theme.colors.copyTwo}`}
+          color="copyTwo"
+          fontSize={fontSizes}
         >
           BACK
-        </MenuButton>
-        <Menu textAlign={["center", null, null, "start"]} p={4}>
+        </BackButton>
+        <Menu textAlign={["center", "center", "start"]} p={4}>
           {links.map(props => (
             <Link key={props.page} onClick={toggleMenuIsOpen} {...props} />
           ))}

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -48,7 +48,7 @@ const OpenNavMenuButton = styled.button<ColorProps & TypographyProps>`
   ${typography};
   border: none;
   background: transparent;
-  transition: transform 1s;
+  transition: transform 0.4s;
   &:hover {
     transform: scale(1.01);
     color: white;

--- a/src/components/projects/conscious-shopping/ConsciousShopping.tsx
+++ b/src/components/projects/conscious-shopping/ConsciousShopping.tsx
@@ -5,27 +5,17 @@ import ConsciousShoppingPreview from "./ConsciousShoppingPreview";
 import Flex from "../../Flex";
 import PreviewOrProjectPage from "../PreviewOrProjectPage";
 import React from "react";
-import styled from "styled-components";
-
-const Main = styled(Flex)<FlexboxProps & TypographyProps>`
-  ${typography};
-`;
 
 const launchDate = "2021-02-19";
 const ConsciousShopping = () => {
   return (
-    <Main
-      flex="auto"
-      justifyContent="center"
-      alignItems="center"
-      fontFamily="secondary"
-    >
+    <Flex flex="auto">
       <PreviewOrProjectPage
         launchDate={launchDate}
         PreviewPage={ConsciousShoppingPreview}
         ProjectPage={ConsciousShoppingContent}
       />
-    </Main>
+    </Flex>
   );
 };
 

--- a/src/components/projects/conscious-shopping/ConsciousShopping.tsx
+++ b/src/components/projects/conscious-shopping/ConsciousShopping.tsx
@@ -1,5 +1,3 @@
-import { FlexboxProps, TypographyProps, typography } from "styled-system";
-
 import ConsciousShoppingContent from "./ConsciousShoppingContent";
 import ConsciousShoppingPreview from "./ConsciousShoppingPreview";
 import Flex from "../../Flex";

--- a/src/components/projects/conscious-shopping/ConsciousShoppingPreview.tsx
+++ b/src/components/projects/conscious-shopping/ConsciousShoppingPreview.tsx
@@ -81,6 +81,7 @@ const ConsciousShoppingPreview: React.FC<{ launchDate: string }> = ({
             left={30}
             top={80}
             position="absolute"
+            display={["none", "none", "block"]}
           />
         </ReturnToProjectsPage>
         <Illustration

--- a/src/components/projects/conscious-shopping/ConsciousShoppingPreview.tsx
+++ b/src/components/projects/conscious-shopping/ConsciousShoppingPreview.tsx
@@ -9,6 +9,7 @@ import {
   position,
 } from "styled-system";
 
+import Flex from "../../Flex";
 import { Link } from "react-router-dom";
 import { PROJECTS_URL } from "../../../constants/router-urls";
 import React from "react";
@@ -28,14 +29,17 @@ const Div = styled.div<GridProps & LayoutProps & FlexboxProps>`
   ${grid};
 `;
 
-const TimerContainer = styled.div<GridProps & PositionProps>`
+const TimerContainer = styled.div<GridProps & LayoutProps>`
   ${grid};
-  ${position}
+  ${layout};
+  z-index: ${theme.zIndexes.inFront};
 `;
 
-const ProjectIcon = styled.img<GridProps & LayoutProps>`
+const ProjectIcon = styled.img<GridProps & LayoutProps & PositionProps>`
   ${layout};
   ${grid};
+  ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: transform 0.4s;
   transform-origin: left;
   &:hover {
@@ -57,75 +61,86 @@ const ConsciousShoppingPreview: React.FC<{ launchDate: string }> = ({
   launchDate,
 }) => {
   return (
-    <Div
-      display={["flex", "flex", "flex", "grid"]}
-      flexDirection={["column", "column", "column"]}
-      gridTemplateColumns="repeat(3, 1fr)"
-      gridTemplateRows="repeat(5, 20%)"
-      alignItems="center"
-      height={["unset", "unset", "unset", "86vh"]}
-    >
-      <ReturnToProjectsPage to={PROJECTS_URL} alignSelf="start">
-        <ProjectIcon
-          src={projectIcon}
-          alt="icon image"
-          maxWidth="20%"
-          gridColumn={1}
-          gridRow={1}
-        />
-      </ReturnToProjectsPage>
-      <Illustration
-        src={boots}
-        alt="illustration image"
-        maxWidth="50%"
-        gridColumn={1}
-        gridRow={2}
-        justifySelf="flex-end"
-        alignSelf="center"
-      />
-      <TimerContainer
-        zIndex={theme.zIndexes.inFront}
-        gridColumn={2}
-        gridRow="2/4"
+    <Flex flex="auto" justifyContent="center" alignItems="center" height="auto">
+      <Div
+        display={["flex", "flex", "flex", "flex", "grid"]}
+        flexDirection="column"
+        gridTemplateColumns="3, 1fr"
+        gridTemplateRows="140px 140px 140px 140px"
+        alignItems="center"
+        width="80%"
       >
-        <Timer launchDate={launchDate} />
-      </TimerContainer>
-      <Illustration
-        src={bag}
-        alt="illustration image"
-        maxWidth="50%"
-        gridColumn={2}
-        gridRow={1}
-        justifySelf="center"
-        alignSelf="center"
-      />
-      <Illustration
-        src={shell}
-        alt="illustration image"
-        maxWidth="50%"
-        gridColumn={2}
-        gridRow={4}
-        justifySelf="flex-start"
-        alignSelf="center"
-      />
-      <Illustration
-        src={trex}
-        alt="illustration image"
-        maxWidth="50%"
-        gridColumn={2}
-        gridRow={4}
-        justifySelf="flex-end"
-        alignSelf="center"
-      />
-      <Illustration
-        src={sunglasses}
-        alt="illustration image"
-        maxWidth="50%"
-        gridColumn={3}
-        gridRow={2}
-        alignSelf="center"
-      />
-    </Div>
+        <ReturnToProjectsPage to={PROJECTS_URL}>
+          <ProjectIcon
+            src={projectIcon}
+            alt="icon image"
+            width={80}
+            minWidth={80}
+            gridColumn={1}
+            gridRow={1}
+            left={30}
+            top={80}
+            position="absolute"
+          />
+        </ReturnToProjectsPage>
+        <Illustration
+          src={boots}
+          alt="illustration image"
+          width={240}
+          minWidth={240}
+          gridColumn={1}
+          gridRow={2}
+          justifySelf="flex-end"
+          alignSelf="center"
+        />
+        <TimerContainer
+          gridColumn={2}
+          gridRow="2/4"
+          width={["auto", "auto", "auto", 444]}
+          minWidth={["auto", "auto", "auto", 444]}
+        >
+          <Timer launchDate={launchDate} />
+        </TimerContainer>
+        <Illustration
+          src={bag}
+          alt="illustration image"
+          width={240}
+          minWidth={240}
+          gridColumn={2}
+          gridRow={1}
+          justifySelf="center"
+        />
+        <Illustration
+          src={shell}
+          alt="illustration image"
+          width={240}
+          minWidth={240}
+          gridColumn={2}
+          gridRow={4}
+          justifySelf="flex-start"
+          alignSelf="center"
+        />
+        <Illustration
+          src={trex}
+          alt="illustration image"
+          width={240}
+          minWidth={240}
+          gridColumn={2}
+          gridRow={4}
+          justifySelf="flex-end"
+          alignSelf="center"
+        />
+        <Illustration
+          src={sunglasses}
+          alt="illustration image"
+          width={240}
+          minWidth={240}
+          gridColumn={3}
+          gridRow="1/3"
+          alignSelf="start"
+        />
+      </Div>
+    </Flex>
   );
 };
 

--- a/src/components/projects/leo-adef/LeoAdef.tsx
+++ b/src/components/projects/leo-adef/LeoAdef.tsx
@@ -116,7 +116,6 @@ const LeoAdefContent: React.FC = () => {
       >
         {calendarImages.map(CalendarImage)}
       </Grid>
-      <Scrollback bottom={40} left={40} />
     </div>
   );
 };


### PR DESCRIPTION
### What changes have you made?
Just made some little changes that have been niggling me for ages.

- I've added a `minWidth` and `width` to all the images on the Conscious Shopping preview page so that there's no more jump 
- I've hidden the `ReturnToProjectPage` icon from Conscious Shopping mobile view to economise on space 
- Refactored the Nav Menu component - many of the buttons share properties so I've tried to keep the code as DRY as possible by extending styled-components and just passing the props that are needed for that particular instance 
- I've removed the scrollback button from the Leo Adef page because having tested it on mobile it's not reeeeally necessary as there's not that much content on the page. The component would be improved by displaying it only when the browser hits a certain view height or element i.e. the footer

### Which issue(s) does this PR fix?

Fixes #231 

### Screenshots (if there are design changes)

### How to test
- There should be no jump on the Conscious Shopping preview page 
- The nav menu should have exactly the same functionality as before - make sure to check that you can click anywhere on the menu to close the nav 
