### PR TITLE
fixes console log warnings

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -11,6 +11,7 @@ import theme from "./theme";
 const BuyButtonContainer = styled.div<PositionProps & SpaceProps>`
   ${position};
   ${space};
+  z-index: ${theme.zIndexes.inFront};
 `;
 
 const Projects = () => {
@@ -20,7 +21,6 @@ const Projects = () => {
       <BuyButtonContainer
         position="fixed"
         bottom={["40%", "40%", "40%", "15%"]}
-        zIndex={theme.zIndexes.inFront}
       >
         <BuyButton />
       </BuyButtonContainer>

--- a/src/components/Scrollback.tsx
+++ b/src/components/Scrollback.tsx
@@ -20,6 +20,7 @@ const Button = styled.button<
   ${typography};
   ${background};
   ${layout};
+  z-index: ${theme.zIndexes.inFront}
   border: none;
 `;
 
@@ -44,7 +45,6 @@ const Scrollback: React.FC<ButtonProps> = props => {
       fontSize={[3, 4]}
       background="transparent"
       onClick={scrollToTop}
-      zIndex={theme.zIndexes.inFront}
     >
       UP
     </Button>

--- a/src/components/projects/conscious-shopping/ConsciousShoppingCarousel.tsx
+++ b/src/components/projects/conscious-shopping/ConsciousShoppingCarousel.tsx
@@ -106,6 +106,7 @@ const ScrollableText = styled.p<TypographyProps & SpaceProps>`
 const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   ${layout};
   ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: all 1s ease;
   &:hover {
     transform: scale(1.05);
@@ -265,11 +266,7 @@ const ConsciousShoppingCarousel = () => {
             width={["100%", "100%", "100%", "100%", "40%"]}
             flexDirection="column"
           >
-            <ReturnToProjectsPage
-              to={PROJECTS_URL}
-              width={60}
-              zIndex={theme.zIndexes.inFront}
-            >
+            <ReturnToProjectsPage to={PROJECTS_URL} width={60}>
               <img src={shellIcon} alt="shell icon" />
             </ReturnToProjectsPage>
             <H1 my={4} fontFamily="secondary">

--- a/src/components/projects/eye/CountryData.tsx
+++ b/src/components/projects/eye/CountryData.tsx
@@ -22,6 +22,7 @@ const bounce = keyframes`
 
 const Container = styled(Flex)`
   animation: ${bounce} 2s linear infinite;
+  z-index: ${theme.zIndexes.behind};
 `;
 
 const P = styled.p<TypographyProps>`
@@ -50,29 +51,33 @@ const CountryData = ({ countryData }: { countryData: EyeData | null }) => {
         position="fixed"
         flexDirection="column"
         width="auto"
-        maxWidth={400}
+        maxWidth={[300, 300, 320, 400, 400]}
         p={2}
         top={100}
-        left={["50%", "50%", "50%", "60%", "75%"]}
-        zIndex={theme.zIndexes.behind}
-        lineHeight="28px"
+        left={["40%", "40%", "45%", "60%", "70%"]}
+        lineHeight="25px"
       >
-        <Flex borderBottom="offWhiteThin" width="fit-content" maxWidth={250}>
+        <Flex
+          borderBottom="offWhiteThin"
+          width="fit-content"
+          maxWidth={[150, 150, 250, 250, 250]}
+          mb={1}
+        >
           <P fontSize={4}>{countryData.name}</P>
         </Flex>
-        <P fontSize={[1, 1, 2, 2]}>
+        <P fontSize={[1, 1, 1, 2]}>
           {t("eye.population")}:{" "}
           {i18n.language === "en"
             ? countryData.data.population.toLocaleString([locales.gb])
             : countryData.data.population.toLocaleString([locales.es])}
         </P>
-        <P fontSize={[1, 1, 2, 2]}>
+        <P fontSize={[1, 1, 1, 2]}>
           {t("eye.populationAffected")}:{" "}
           {i18n.language === "en"
             ? countryData.data.populationAffected.toLocaleString([locales.gb])
             : countryData.data.populationAffected.toLocaleString([locales.es])}
         </P>
-        <P fontSize={[1, 1, 2, 2]}>
+        <P fontSize={[1, 1, 1, 2]}>
           {t("eye.percentage")}:{" "}
           {i18n.language === "en"
             ? countryData.data.percentageAffected.toLocaleString([locales.gb])
@@ -80,7 +85,7 @@ const CountryData = ({ countryData }: { countryData: EyeData | null }) => {
           %
         </P>
         {countryData.data.casesTreated ? (
-          <P fontSize={[1, 1, 2, 2]}>
+          <P fontSize={[1, 1, 1, 2]}>
             {t("eye.recovered")}:{" "}
             {i18n.language === "en"
               ? countryData.data.casesTreated.toLocaleString([locales.gb])

--- a/src/components/projects/eye/Eye.tsx
+++ b/src/components/projects/eye/Eye.tsx
@@ -70,6 +70,7 @@ const getRelativeValues = ({
 const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   ${layout};
   ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: all 1s ease;
   &:hover {
     transform: scale(1.05);
@@ -199,7 +200,6 @@ const EyeContent = () => {
         position="fixed"
         left={40}
         top={80}
-        zIndex={theme.zIndexes.inFront}
       >
         <img src={eye} alt="eye icon" />
       </ReturnToProjectsPage>
@@ -228,7 +228,7 @@ const EyeContent = () => {
             ))}
           </Grid>
         </LazyLoad>
-        <Flex display={["none", "none", "none", "none", "block"]}>
+        <Flex>
           <CountryData countryData={selectedCountryData} />
         </Flex>
         <Flex
@@ -250,7 +250,6 @@ const EyeContent = () => {
           left={400}
           width={320}
           px={2}
-          zIndex={theme.zIndexes.behind}
         >
           <P
             dangerouslySetInnerHTML={{ __html: t("eye.footnote") }}

--- a/src/components/projects/fashion-editorial/FashionEditorial.tsx
+++ b/src/components/projects/fashion-editorial/FashionEditorial.tsx
@@ -173,6 +173,7 @@ const Img = styled.img`
 const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   ${layout};
   ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: all 1s ease;
   &:hover {
     transform: scale(1.05);
@@ -202,7 +203,6 @@ const FashionEditorialContent: React.FC = () => {
         position="absolute"
         left={40}
         top={80}
-        zIndex={theme.zIndexes.inFront}
         display={["none", "none", "block"]}
       >
         <img src={stairs} alt="mask icon" />

--- a/src/components/projects/kai-landre/KaiLandre.tsx
+++ b/src/components/projects/kai-landre/KaiLandre.tsx
@@ -14,6 +14,7 @@ import theme from "../../theme";
 const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   ${layout};
   ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: all 1s ease;
   &:hover {
     transform: scale(1.05);
@@ -32,7 +33,6 @@ const KaiLandreContent = () => {
         height="100%"
         controls
         playing
-        zindex={theme.zIndexes.behind}
       ></ReactPlayer>
       <ReturnToProjectsPage
         to={PROJECTS_URL}

--- a/src/components/projects/leo-adef/LeoAdef.tsx
+++ b/src/components/projects/leo-adef/LeoAdef.tsx
@@ -105,6 +105,7 @@ interface CalendarImageProps {
 const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   ${layout};
   ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: all 1s ease;
   &:hover {
     transform: scale(1.05);
@@ -130,7 +131,6 @@ const LeoAdefContent: React.FC = () => {
         position="absolute"
         left={40}
         top={100}
-        zIndex={theme.zIndexes.inFront}
         display={["none", "none", "block"]}
       >
         <img src={knife} alt="mask icon" />

--- a/src/components/projects/marc-medina/MarcMedina.tsx
+++ b/src/components/projects/marc-medina/MarcMedina.tsx
@@ -173,6 +173,7 @@ const Img = styled.img`
 const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
   ${layout};
   ${position};
+  z-index: ${theme.zIndexes.inFront};
   transition: all 1s ease;
   &:hover {
     transform: scale(1.05);
@@ -202,7 +203,6 @@ const MarcMedinaContent: React.FC = () => {
         position="absolute"
         left={40}
         top={80}
-        zIndex={theme.zIndexes.inFront}
         display={["none", "none", "block"]}
       >
         <img src={mask} alt="mask icon" />

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,6 @@
-import i18n from "i18next";
 import Backend from "i18next-xhr-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
+import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
 const fallbackLng = ["en"];
@@ -16,7 +16,7 @@ i18n
   .init({
     fallbackLng, // if user computer language is not on the list of available languages, than we will be using the fallback language specified earlier
     debug: true,
-    whitelist: availableLanguages,
+    supportedLngs: availableLanguages,
 
     interpolation: {
       escapeValue: false,


### PR DESCRIPTION
### What changes have you made?
- the main offender for the console log warnings was the use of `zIndex` in the return statement as it's not DOM supported
- I've removed all instances of passing `zIndex` as a prop using JSX and  applied `z-Index` in the CSS of the styled component instead 
- `isWhitelisted` will soon be deprecated from i18n and renamed to  "isSupportedCode" so I've updated the `init` method with the key value `supportedLngs: availableLanguages` in the `18n.ts` file 
<img width="1040" alt="Screenshot 2021-02-22 at 18 03 22" src="https://user-images.githubusercontent.com/53219789/108749897-4b7c7c80-7538-11eb-9eff-89d072bd7e5e.png">


### Which issue(s) does this PR fix?

Fixes #373 

### Screenshots (if there are design changes)

### How to test
Check in the console that there are no fixable errors like unused props, elements not recognised by the DOM etc 