### PR TITLE
removes usage of lazyload from components with loading bug

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -11,7 +11,6 @@ import {
 
 import Flex from "./Flex";
 import Grid from "./Grid";
-import LazyLoad from "react-lazyload";
 import React from "react";
 import aitor from "../assets/about-page/aitor.jpg";
 import gloria from "../assets/about-page/gloria.jpg";
@@ -79,7 +78,7 @@ const TeamMemberImg = styled.img`
   width: 100%;
 `;
 
-const TeamMemberContainer = styled(LazyLoad)`
+const TeamMemberContainer = styled.div`
   object-fit: contain;
   height: 100%;
 `;

--- a/src/components/Advertising.tsx
+++ b/src/components/Advertising.tsx
@@ -8,7 +8,6 @@ import {
 } from "styled-system";
 
 import Flex from "./Flex";
-import LazyLoad from "react-lazyload";
 import React from "react";
 import honestCouponsImg from "../assets/advertising-page/honest-coupons.jpeg";
 import salazrakiImg from "../assets/advertising-page/salazraki.jpg";
@@ -37,41 +36,39 @@ const Advertising = () => {
   const columnWidths = "100%";
 
   return (
-    <LazyLoad once>
-      <Flex flex="auto" flexDirection="column">
-        <Flex flexDirection={["column", "column", "column", "row"]}>
-          <Flex flexDirection="column" width={columnWidths} mr={[0, 0, 2]}>
-            <Img src={voltrovaImg} alt="Advertsing image" />
-            <P
-              fontSize={fontSizes}
-              textAlign="justify"
-              mt={[2, 2, 4]}
-              mb={6}
-              dangerouslySetInnerHTML={{ __html: voltrova }}
-            ></P>
-          </Flex>
+    <Flex flex="auto" flexDirection="column">
+      <Flex flexDirection={["column", "column", "column", "row"]}>
+        <Flex flexDirection="column" width={columnWidths} mr={[0, 0, 2]}>
+          <Img src={voltrovaImg} alt="Advertsing image" />
+          <P
+            fontSize={fontSizes}
+            textAlign="justify"
+            mt={[2, 2, 4]}
+            mb={6}
+            dangerouslySetInnerHTML={{ __html: voltrova }}
+          ></P>
+        </Flex>
 
-          <Flex flexDirection="column" width={columnWidths} ml={[0, 0, 2]}>
-            <Img src={honestCouponsImg} alt="Advertsing image" />
-            <P
-              fontSize={fontSizes}
-              textAlign="justify"
-              mt={[2, 2, 4]}
-              mb={6}
-              dangerouslySetInnerHTML={{ __html: honestCoupons }}
-            ></P>
-            <Img src={salazrakiImg} alt="Advertsing image" />
-            <P
-              fontSize={fontSizes}
-              textAlign="justify"
-              mt={[2, 2, 4]}
-              mb={6}
-              dangerouslySetInnerHTML={{ __html: salazraki }}
-            ></P>
-          </Flex>
+        <Flex flexDirection="column" width={columnWidths} ml={[0, 0, 2]}>
+          <Img src={honestCouponsImg} alt="Advertsing image" />
+          <P
+            fontSize={fontSizes}
+            textAlign="justify"
+            mt={[2, 2, 4]}
+            mb={6}
+            dangerouslySetInnerHTML={{ __html: honestCoupons }}
+          ></P>
+          <Img src={salazrakiImg} alt="Advertsing image" />
+          <P
+            fontSize={fontSizes}
+            textAlign="justify"
+            mt={[2, 2, 4]}
+            mb={6}
+            dangerouslySetInnerHTML={{ __html: salazraki }}
+          ></P>
         </Flex>
       </Flex>
-    </LazyLoad>
+    </Flex>
   );
 };
 

--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -17,7 +17,6 @@ import {
 import styled, { css } from "styled-components";
 
 import Flex from "./Flex";
-import LazyLoad from "react-lazyload";
 import React from "react";
 import eyeProjectBackground from "../assets/backgrounds/eye-bg.png";
 import marbleBackground from "../assets/backgrounds/background.png";
@@ -28,7 +27,7 @@ const black = `${theme.colors.copyTwo}`;
 
 type Background = typeof black | typeof marbleBackground;
 
-const BackgroundElement = styled(LazyLoad)<{ background: Background }>`
+const BackgroundElement = styled.div<{ background: Background }>`
   position: fixed;
   top: 0;
   right: 0;

--- a/src/components/projects/fashion-editorial/FashionEditorial.tsx
+++ b/src/components/projects/fashion-editorial/FashionEditorial.tsx
@@ -9,7 +9,6 @@ import {
 
 import FashionEditorialPreview from "./FashionEditorialPreview";
 import Flex from "../../Flex";
-import LazyLoad from "react-lazyload";
 import { Link } from "react-router-dom";
 import { PROJECTS_URL } from "../../../constants/router-urls";
 import PreviewOrProjectPage from "../PreviewOrProjectPage";
@@ -159,7 +158,7 @@ const Div = styled.div<GridProps & LayoutProps>`
   ${grid};
 `;
 
-const ImgContainer = styled(LazyLoad)<GridProps>`
+const ImgContainer = styled.div<GridProps>`
   object-fit: contain;
   height: 100%;
   ${grid};

--- a/src/components/projects/leo-adef/LeoAdef.tsx
+++ b/src/components/projects/leo-adef/LeoAdef.tsx
@@ -2,7 +2,6 @@ import { LayoutProps, PositionProps, layout, position } from "styled-system";
 
 import Flex from "../../Flex";
 import Grid from "../../Grid";
-import LazyLoad from "react-lazyload";
 import LeoAdefPreview from "./LeoAdefPreview";
 import { Link } from "react-router-dom";
 import { PROJECTS_URL } from "../../../constants/router-urls";
@@ -114,11 +113,9 @@ const ReturnToProjectsPage = styled(Link)<LayoutProps & PositionProps>`
 
 const CalendarImage = ({ img, alt }: CalendarImageProps) => {
   return (
-    <LazyLoad once>
-      <Container key={img}>
-        <Image alt={alt} src={img} />
-      </Container>
-    </LazyLoad>
+    <Container key={img}>
+      <Image alt={alt} src={img} />
+    </Container>
   );
 };
 

--- a/src/components/projects/marc-medina/MarcMedina.tsx
+++ b/src/components/projects/marc-medina/MarcMedina.tsx
@@ -8,7 +8,6 @@ import {
 } from "styled-system";
 
 import Flex from "../../Flex";
-import LazyLoad from "react-lazyload";
 import { Link } from "react-router-dom";
 import MarcMedinaPreview from "./MarcMedinaPreview";
 import { PROJECTS_URL } from "../../../constants/router-urls";
@@ -159,7 +158,7 @@ const Div = styled.div<GridProps & LayoutProps>`
   ${grid};
 `;
 
-const ImgContainer = styled(LazyLoad)<GridProps>`
+const ImgContainer = styled.div<GridProps>`
   object-fit: contain;
   height: 100%;
   ${grid};


### PR DESCRIPTION
### What changes have you made?

- removed lazy load from components where images were not rendering after returning from the buy page
- removed lazy load from components where image load was stalling on first render

### Which issue(s) does this PR fix?

Fixes #404 

### Screenshots (if there are design changes)

### How to test
Go to any project page and test that the images render when returning from the buy page 