### PR TITLE
fixes display bug on safari

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -110,7 +110,7 @@ const About = () => {
   const { t } = useTranslation();
 
   return (
-    <Flex flex="auto" flexDirection="column">
+    <Flex flex="auto" flexDirection="column" height="100vh">
       <H1 fontSize={[4, 5, 5, 6]} my={4}>
         {t("about.header")}
       </H1>


### PR DESCRIPTION
### What changes have you made?

- added a fixed height to the about page to fix the image stretch on safari



### Which issue(s) does this PR fix?

Fixes #403 

### Screenshots (if there are design changes)
Before: 

<img width="1438" alt="Screenshot 2021-03-08 at 19 29 05" src="https://user-images.githubusercontent.com/53219789/110371488-f581fb80-8044-11eb-88d8-39ad42a2ea1e.png">



After: 

<img width="1438" alt="Screenshot 2021-03-08 at 19 29 17" src="https://user-images.githubusercontent.com/53219789/110371358-c66b8a00-8044-11eb-83a9-2e5676e1f4b9.png">


### How to test
http://localhost:3000/about
