### PR TITLE
removes fixed video height

### DIFF
--- a/src/components/projects/kai-landre/KaiLandre.tsx
+++ b/src/components/projects/kai-landre/KaiLandre.tsx
@@ -25,7 +25,7 @@ const KaiLandreContent = () => {
   const url = "https://youtu.be/fjnXLRrHscM";
 
   return (
-    <Flex flex="auto" height={["76vh", "76vh", "76vh", "80vh", "80vh"]}>
+    <Flex flex="auto">
       <ReactPlayer
         url={url}
         position="relative"
@@ -38,8 +38,8 @@ const KaiLandreContent = () => {
         to={PROJECTS_URL}
         width={80}
         position="absolute"
-        right={60}
-        bottom={100}
+        right={75}
+        bottom={0}
         display={["none", "none", "none", "block"]}
       >
         <img src={dragon} alt="dragon icon" />


### PR DESCRIPTION
### What changes have you made?
- removed any fixed height from the kai landre video to optimise screen usage 

### Which issue(s) does this PR fix?
N/A

### Screenshots (if there are design changes)
<img width="1438" alt="Screenshot 2021-03-09 at 20 09 58" src="https://user-images.githubusercontent.com/53219789/110531429-73acd380-8113-11eb-86a8-2ceb115fb5a9.png">


### How to test
http://localhost:3000/projects/kailandre